### PR TITLE
Added object caching support

### DIFF
--- a/scala-debugger-api/src/main/scala/org/scaladebugger/api/dsl/Implicits.scala
+++ b/scala-debugger-api/src/main/scala/org/scaladebugger/api/dsl/Implicits.scala
@@ -1,27 +1,27 @@
 package org.scaladebugger.api.dsl
 
 import org.scaladebugger.api.dsl.breakpoints.BreakpointDSLWrapper
-import org.scaladebugger.api.dsl.classes.{ClassUnloadDSLWrapper, ClassPrepareDSLWrapper}
+import org.scaladebugger.api.dsl.classes.{ClassPrepareDSLWrapper, ClassUnloadDSLWrapper}
 import org.scaladebugger.api.dsl.events.EventDSLWrapper
 import org.scaladebugger.api.dsl.exceptions.ExceptionDSLWrapper
-import org.scaladebugger.api.dsl.info.{GrabInfoDSLWrapper, FrameInfoDSLWrapper}
-import org.scaladebugger.api.dsl.methods.{MethodExitDSLWrapper, MethodEntryDSLWrapper}
-import org.scaladebugger.api.dsl.monitors.{MonitorWaitDSLWrapper, MonitorWaitedDSLWrapper, MonitorContendedEnterDSLWrapper, MonitorContendedEnteredDSLWrapper}
+import org.scaladebugger.api.dsl.info.{FrameInfoDSLWrapper, GrabInfoDSLWrapper, ObjectInfoDSLWrapper}
+import org.scaladebugger.api.dsl.methods.{MethodEntryDSLWrapper, MethodExitDSLWrapper}
+import org.scaladebugger.api.dsl.monitors.{MonitorContendedEnterDSLWrapper, MonitorContendedEnteredDSLWrapper, MonitorWaitDSLWrapper, MonitorWaitedDSLWrapper}
 import org.scaladebugger.api.dsl.steps.StepDSLWrapper
-import org.scaladebugger.api.dsl.threads.{ThreadStartDSLWrapper, ThreadDeathDSLWrapper}
-import org.scaladebugger.api.dsl.vm.{VMStartDSLWrapper, VMDisconnectDSLWrapper, VMDeathDSLWrapper}
-import org.scaladebugger.api.dsl.watchpoints.{ModificationWatchpointDSLWrapper, AccessWatchpointDSLWrapper}
+import org.scaladebugger.api.dsl.threads.{ThreadDeathDSLWrapper, ThreadStartDSLWrapper}
+import org.scaladebugger.api.dsl.vm.{VMDeathDSLWrapper, VMDisconnectDSLWrapper, VMStartDSLWrapper}
+import org.scaladebugger.api.dsl.watchpoints.{AccessWatchpointDSLWrapper, ModificationWatchpointDSLWrapper}
 import org.scaladebugger.api.profiles.traits.breakpoints.BreakpointProfile
-import org.scaladebugger.api.profiles.traits.classes.{ClassUnloadProfile, ClassPrepareProfile}
+import org.scaladebugger.api.profiles.traits.classes.{ClassPrepareProfile, ClassUnloadProfile}
 import org.scaladebugger.api.profiles.traits.events.EventProfile
 import org.scaladebugger.api.profiles.traits.exceptions.ExceptionProfile
-import org.scaladebugger.api.profiles.traits.info.{GrabInfoProfile, FrameInfoProfile}
-import org.scaladebugger.api.profiles.traits.methods.{MethodExitProfile, MethodEntryProfile}
-import org.scaladebugger.api.profiles.traits.monitors.{MonitorWaitProfile, MonitorWaitedProfile, MonitorContendedEnterProfile, MonitorContendedEnteredProfile}
+import org.scaladebugger.api.profiles.traits.info.{FrameInfoProfile, GrabInfoProfile, ObjectInfoProfile}
+import org.scaladebugger.api.profiles.traits.methods.{MethodEntryProfile, MethodExitProfile}
+import org.scaladebugger.api.profiles.traits.monitors.{MonitorContendedEnterProfile, MonitorContendedEnteredProfile, MonitorWaitProfile, MonitorWaitedProfile}
 import org.scaladebugger.api.profiles.traits.steps.StepProfile
-import org.scaladebugger.api.profiles.traits.threads.{ThreadStartProfile, ThreadDeathProfile}
-import org.scaladebugger.api.profiles.traits.vm.{VMStartProfile, VMDisconnectProfile, VMDeathProfile}
-import org.scaladebugger.api.profiles.traits.watchpoints.{ModificationWatchpointProfile, AccessWatchpointProfile}
+import org.scaladebugger.api.profiles.traits.threads.{ThreadDeathProfile, ThreadStartProfile}
+import org.scaladebugger.api.profiles.traits.vm.{VMDeathProfile, VMDisconnectProfile, VMStartProfile}
+import org.scaladebugger.api.profiles.traits.watchpoints.{AccessWatchpointProfile, ModificationWatchpointProfile}
 
 /**
  * Contains implicit classes to provide DSL-like methods to the debugger API.
@@ -93,6 +93,11 @@ object Implicits {
   implicit def MonitorWaitDSL(
     monitorWaitProfile: MonitorWaitProfile
   ): MonitorWaitDSLWrapper = new MonitorWaitDSLWrapper(monitorWaitProfile)
+
+  /** Converts object info profile to implicit DSL wrapping. */
+  implicit def ObjectInfoDSL(
+    objectInfoProfile: ObjectInfoProfile
+  ): ObjectInfoDSLWrapper = new ObjectInfoDSLWrapper(objectInfoProfile)
 
   /** Converts step profile to implicit DSL wrapping. */
   implicit def StepDSL(

--- a/scala-debugger-api/src/main/scala/org/scaladebugger/api/dsl/info/ObjectInfoDSLWrapper.scala
+++ b/scala-debugger-api/src/main/scala/org/scaladebugger/api/dsl/info/ObjectInfoDSLWrapper.scala
@@ -1,0 +1,39 @@
+package org.scaladebugger.api.dsl.info
+
+import org.scaladebugger.api.profiles.traits.info.ObjectInfoProfile
+import org.scaladebugger.api.virtualmachines.ObjectCache
+
+/**
+ * Wraps a profile, providing DSL-like syntax.
+ *
+ * @param objectInfo The profile to wrap
+ */
+class ObjectInfoDSLWrapper private[dsl] (
+  private val objectInfo: ObjectInfoProfile
+) {
+  /**
+   * Caches this object in its associated JVM cache.
+   *
+   * @param objectCache The JVM cache to store this object
+   * @return The stored object
+   */
+  def cache()(
+    implicit objectCache: ObjectCache = objectInfo.scalaVirtualMachine.cache
+  ): ObjectInfoProfile = {
+    objectCache.save(objectInfo)
+    objectInfo
+  }
+
+  /**
+   * Removes this object from its associated JVM cache.
+   *
+   * @param objectCache The JVM cache to remove this object
+   * @return The removed object
+   */
+  def uncache()(
+    implicit objectCache: ObjectCache = objectInfo.scalaVirtualMachine.cache
+  ): ObjectInfoProfile = {
+    objectCache.remove(objectInfo.uniqueId)
+    objectInfo
+  }
+}

--- a/scala-debugger-api/src/main/scala/org/scaladebugger/api/profiles/Constants.scala
+++ b/scala-debugger-api/src/main/scala/org/scaladebugger/api/profiles/Constants.scala
@@ -1,5 +1,5 @@
 package org.scaladebugger.api.profiles
-import acyclic.file
+//import acyclic.file
 
 /**
  * Contains constants related to the profiles.

--- a/scala-debugger-api/src/main/scala/org/scaladebugger/api/profiles/ProfileManager.scala
+++ b/scala-debugger-api/src/main/scala/org/scaladebugger/api/profiles/ProfileManager.scala
@@ -1,5 +1,5 @@
 package org.scaladebugger.api.profiles
-import acyclic.file
+//import acyclic.file
 
 import org.scaladebugger.api.profiles.traits.DebugProfile
 

--- a/scala-debugger-api/src/main/scala/org/scaladebugger/api/profiles/StandardProfileManager.scala
+++ b/scala-debugger-api/src/main/scala/org/scaladebugger/api/profiles/StandardProfileManager.scala
@@ -1,5 +1,5 @@
 package org.scaladebugger.api.profiles
-import acyclic.file
+//import acyclic.file
 
 import java.util.concurrent.ConcurrentHashMap
 
@@ -81,7 +81,7 @@ object StandardProfileManager {
     //       null will cause usage of it to fail
     profileManager.register(PureDebugProfile.Name, new PureDebugProfile(
       null, managerContainer
-    ))
+    )(_virtualMachine = null))
 
     profileManager
   }

--- a/scala-debugger-api/src/main/scala/org/scaladebugger/api/profiles/pure/PureDebugProfile.scala
+++ b/scala-debugger-api/src/main/scala/org/scaladebugger/api/profiles/pure/PureDebugProfile.scala
@@ -1,20 +1,20 @@
 package org.scaladebugger.api.profiles.pure
-import acyclic.file
-
+//import acyclic.file
 import com.sun.jdi.VirtualMachine
 import org.scaladebugger.api.lowlevel.ManagerContainer
 import org.scaladebugger.api.profiles.pure.breakpoints.PureBreakpointProfile
-import org.scaladebugger.api.profiles.pure.classes.{PureClassUnloadProfile, PureClassPrepareProfile}
+import org.scaladebugger.api.profiles.pure.classes.{PureClassPrepareProfile, PureClassUnloadProfile}
 import org.scaladebugger.api.profiles.pure.events.PureEventProfile
 import org.scaladebugger.api.profiles.pure.exceptions.PureExceptionProfile
 import org.scaladebugger.api.profiles.pure.info.{PureGrabInfoProfile, PureMiscInfoProfile}
-import org.scaladebugger.api.profiles.pure.methods.{PureMethodExitProfile, PureMethodEntryProfile}
-import org.scaladebugger.api.profiles.pure.monitors.{PureMonitorWaitProfile, PureMonitorWaitedProfile, PureMonitorContendedEnterProfile, PureMonitorContendedEnteredProfile}
+import org.scaladebugger.api.profiles.pure.methods.{PureMethodEntryProfile, PureMethodExitProfile}
+import org.scaladebugger.api.profiles.pure.monitors.{PureMonitorContendedEnterProfile, PureMonitorContendedEnteredProfile, PureMonitorWaitProfile, PureMonitorWaitedProfile}
 import org.scaladebugger.api.profiles.pure.steps.PureStepProfile
-import org.scaladebugger.api.profiles.pure.threads.{PureThreadStartProfile, PureThreadDeathProfile}
-import org.scaladebugger.api.profiles.pure.vm.{PureVMDisconnectProfile, PureVMStartProfile, PureVMDeathProfile}
+import org.scaladebugger.api.profiles.pure.threads.{PureThreadDeathProfile, PureThreadStartProfile}
+import org.scaladebugger.api.profiles.pure.vm.{PureVMDeathProfile, PureVMDisconnectProfile, PureVMStartProfile}
 import org.scaladebugger.api.profiles.pure.watchpoints.{PureAccessWatchpointProfile, PureModificationWatchpointProfile}
-import org.scaladebugger.api.profiles.traits.{ManagerContainerDebugProfile, DebugProfile}
+import org.scaladebugger.api.profiles.traits.{DebugProfile, ManagerContainerDebugProfile}
+import org.scaladebugger.api.virtualmachines.ScalaVirtualMachine
 
 /**
  * Contains information about the pure debug profile.
@@ -27,14 +27,18 @@ object PureDebugProfile {
  * Represents a debug profile that adds no extra logic on top of the standard
  * JDI.
  *
- * @param _virtualMachine The underlying virtual machine to use for various
- *                        retrieval methods
+ * @param scalaVirtualMachine The high-level virtual machine using this profile
  * @param managerContainer The container of low-level managers to use as the
  *                         underlying implementation
+ * @param _virtualMachine The underlying virtual machine to use for various
+ *                        retrieval methods
  */
 class PureDebugProfile(
-  protected val _virtualMachine: VirtualMachine,
+  protected val scalaVirtualMachine: ScalaVirtualMachine,
   protected val managerContainer: ManagerContainer
+)(
+  protected val _virtualMachine: VirtualMachine =
+    scalaVirtualMachine.underlyingVirtualMachine
 ) extends ManagerContainerDebugProfile
   with PureAccessWatchpointProfile
   with PureBreakpointProfile

--- a/scala-debugger-api/src/main/scala/org/scaladebugger/api/profiles/pure/breakpoints/PureBreakpointProfile.scala
+++ b/scala-debugger-api/src/main/scala/org/scaladebugger/api/profiles/pure/breakpoints/PureBreakpointProfile.scala
@@ -1,5 +1,5 @@
 package org.scaladebugger.api.profiles.pure.breakpoints
-import acyclic.file
+//import acyclic.file
 
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.atomic.AtomicInteger

--- a/scala-debugger-api/src/main/scala/org/scaladebugger/api/profiles/pure/classes/PureClassPrepareProfile.scala
+++ b/scala-debugger-api/src/main/scala/org/scaladebugger/api/profiles/pure/classes/PureClassPrepareProfile.scala
@@ -1,5 +1,5 @@
 package org.scaladebugger.api.profiles.pure.classes
-import acyclic.file
+//import acyclic.file
 
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.atomic.AtomicInteger

--- a/scala-debugger-api/src/main/scala/org/scaladebugger/api/profiles/pure/classes/PureClassUnloadProfile.scala
+++ b/scala-debugger-api/src/main/scala/org/scaladebugger/api/profiles/pure/classes/PureClassUnloadProfile.scala
@@ -1,5 +1,5 @@
 package org.scaladebugger.api.profiles.pure.classes
-import acyclic.file
+//import acyclic.file
 
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.atomic.AtomicInteger

--- a/scala-debugger-api/src/main/scala/org/scaladebugger/api/profiles/pure/events/PureEventProfile.scala
+++ b/scala-debugger-api/src/main/scala/org/scaladebugger/api/profiles/pure/events/PureEventProfile.scala
@@ -1,5 +1,5 @@
 package org.scaladebugger.api.profiles.pure.events
-import acyclic.file
+//import acyclic.file
 
 import org.scaladebugger.api.lowlevel.JDIArgument
 import org.scaladebugger.api.lowlevel.events.{PendingEventHandlerSupportLike, EventHandlerInfo, EventManager}

--- a/scala-debugger-api/src/main/scala/org/scaladebugger/api/profiles/pure/exceptions/PureExceptionProfile.scala
+++ b/scala-debugger-api/src/main/scala/org/scaladebugger/api/profiles/pure/exceptions/PureExceptionProfile.scala
@@ -1,5 +1,5 @@
 package org.scaladebugger.api.profiles.pure.exceptions
-import acyclic.file
+//import acyclic.file
 
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.atomic.AtomicInteger

--- a/scala-debugger-api/src/main/scala/org/scaladebugger/api/profiles/pure/info/PureArrayInfoProfile.scala
+++ b/scala-debugger-api/src/main/scala/org/scaladebugger/api/profiles/pure/info/PureArrayInfoProfile.scala
@@ -3,6 +3,7 @@ package org.scaladebugger.api.profiles.pure.info
 
 import com.sun.jdi._
 import org.scaladebugger.api.profiles.traits.info.{ArrayInfoProfile, ValueInfoProfile}
+import org.scaladebugger.api.virtualmachines.ScalaVirtualMachine
 
 import scala.util.Try
 
@@ -10,6 +11,8 @@ import scala.util.Try
  * Represents a pure implementation of an array profile that adds no custom
  * logic on top of the standard JDI.
  *
+ * @param scalaVirtualMachine The high-level virtual machine containing the
+ *                            array
  * @param arrayReference The reference to the underlying JDI array
  * @param virtualMachine The virtual machine used to mirror local values on
  *                       the remote JVM
@@ -18,12 +21,13 @@ import scala.util.Try
  * @param referenceType The reference type for this array
  */
 class PureArrayInfoProfile(
+  override val scalaVirtualMachine: ScalaVirtualMachine,
   private val arrayReference: ArrayReference
 )(
   private val virtualMachine: VirtualMachine = arrayReference.virtualMachine(),
   private val threadReference: ThreadReference = arrayReference.owningThread(),
   private val referenceType: ReferenceType = arrayReference.referenceType()
-) extends PureObjectInfoProfile(arrayReference)(
+) extends PureObjectInfoProfile(scalaVirtualMachine, arrayReference)(
   virtualMachine = virtualMachine,
   threadReference = threadReference,
   referenceType = referenceType
@@ -129,5 +133,5 @@ class PureArrayInfoProfile(
   }
 
   override protected def newValueProfile(value: Value): ValueInfoProfile =
-    new PureValueInfoProfile(value)
+    new PureValueInfoProfile(scalaVirtualMachine, value)
 }

--- a/scala-debugger-api/src/main/scala/org/scaladebugger/api/profiles/pure/info/PureClassLoaderInfoProfile.scala
+++ b/scala-debugger-api/src/main/scala/org/scaladebugger/api/profiles/pure/info/PureClassLoaderInfoProfile.scala
@@ -5,6 +5,7 @@ package org.scaladebugger.api.profiles.pure.info
 import com.sun.jdi._
 import org.scaladebugger.api.lowlevel.{InvokeNonVirtualArgument, InvokeSingleThreadedArgument, JDIArgument}
 import org.scaladebugger.api.profiles.traits.info._
+import org.scaladebugger.api.virtualmachines.ScalaVirtualMachine
 
 import scala.collection.JavaConverters._
 
@@ -12,6 +13,8 @@ import scala.collection.JavaConverters._
  * Represents a pure implementation of a class loader profile that adds no
  * custom logic on top of the standard JDI.
  *
+ * @param scalaVirtualMachine The high-level virtual machine containing the
+ *                            class loader
  * @param classLoaderReference The reference to the underlying JDI class loader
  * @param virtualMachine The virtual machine associated with the class loader
  * @param threadReference The thread associated with the class loader
@@ -19,12 +22,13 @@ import scala.collection.JavaConverters._
  * @param referenceType The reference type for this class loader
  */
 class PureClassLoaderInfoProfile(
+  override val scalaVirtualMachine: ScalaVirtualMachine,
   private val classLoaderReference: ClassLoaderReference
 )(
   private val virtualMachine: VirtualMachine = classLoaderReference.virtualMachine(),
   private val threadReference: ThreadReference = classLoaderReference.owningThread(),
   private val referenceType: ReferenceType = classLoaderReference.referenceType()
-) extends PureObjectInfoProfile(classLoaderReference)(
+) extends PureObjectInfoProfile(scalaVirtualMachine, classLoaderReference)(
   virtualMachine = virtualMachine,
   threadReference = threadReference,
   referenceType = referenceType

--- a/scala-debugger-api/src/main/scala/org/scaladebugger/api/profiles/pure/info/PureClassObjectInfoProfile.scala
+++ b/scala-debugger-api/src/main/scala/org/scaladebugger/api/profiles/pure/info/PureClassObjectInfoProfile.scala
@@ -4,11 +4,14 @@ package org.scaladebugger.api.profiles.pure.info
 
 import com.sun.jdi._
 import org.scaladebugger.api.profiles.traits.info._
+import org.scaladebugger.api.virtualmachines.ScalaVirtualMachine
 
 /**
  * Represents a pure implementation of a class object profile that adds no
  * custom logic on top of the standard JDI.
  *
+ * @param scalaVirtualMachine The high-level virtual machine containing the
+ *                            class object
  * @param classObjectReference The reference to the underlying JDI class object
  * @param virtualMachine The virtual machine associated with the class object
  * @param threadReference The thread associated with the class object
@@ -16,12 +19,13 @@ import org.scaladebugger.api.profiles.traits.info._
  * @param referenceType The reference type for this class object
  */
 class PureClassObjectInfoProfile(
+  override val scalaVirtualMachine: ScalaVirtualMachine,
   private val classObjectReference: ClassObjectReference
 )(
   private val virtualMachine: VirtualMachine = classObjectReference.virtualMachine(),
   private val threadReference: ThreadReference = classObjectReference.owningThread(),
   private val referenceType: ReferenceType = classObjectReference.referenceType()
-) extends PureObjectInfoProfile(classObjectReference)(
+) extends PureObjectInfoProfile(scalaVirtualMachine, classObjectReference)(
   virtualMachine = virtualMachine,
   threadReference = threadReference,
   referenceType = referenceType

--- a/scala-debugger-api/src/main/scala/org/scaladebugger/api/profiles/pure/info/PureFieldInfoProfile.scala
+++ b/scala-debugger-api/src/main/scala/org/scaladebugger/api/profiles/pure/info/PureFieldInfoProfile.scala
@@ -3,6 +3,7 @@ package org.scaladebugger.api.profiles.pure.info
 
 import com.sun.jdi._
 import org.scaladebugger.api.profiles.traits.info.{ValueInfoProfile, VariableInfoProfile}
+import org.scaladebugger.api.virtualmachines.ScalaVirtualMachine
 
 import scala.util.Try
 
@@ -10,12 +11,15 @@ import scala.util.Try
  * Represents a pure implementation of a field profile that adds no custom
  * logic on top of the standard JDI.
  *
+ * @param scalaVirtualMachine The high-level virtual machine containing the
+ *                            field
  * @param objectReference The object associated with the field instance
  * @param field The reference to the underlying JDI field
  * @param virtualMachine The virtual machine used to mirror local values on
  *                       the remote JVM
  */
 class PureFieldInfoProfile(
+  val scalaVirtualMachine: ScalaVirtualMachine,
   private val objectReference: ObjectReference,
   private val field: Field
 )(
@@ -103,5 +107,5 @@ class PureFieldInfoProfile(
   }
 
   protected def newValueProfile(value: Value): ValueInfoProfile =
-    new PureValueInfoProfile(value)
+    new PureValueInfoProfile(scalaVirtualMachine, value)
 }

--- a/scala-debugger-api/src/main/scala/org/scaladebugger/api/profiles/pure/info/PureFrameInfoProfile.scala
+++ b/scala-debugger-api/src/main/scala/org/scaladebugger/api/profiles/pure/info/PureFrameInfoProfile.scala
@@ -3,6 +3,7 @@ package org.scaladebugger.api.profiles.pure.info
 
 import com.sun.jdi._
 import org.scaladebugger.api.profiles.traits.info._
+import org.scaladebugger.api.virtualmachines.ScalaVirtualMachine
 
 import scala.util.{Failure, Try}
 import scala.collection.JavaConverters._
@@ -11,10 +12,13 @@ import scala.collection.JavaConverters._
  * Represents a pure implementation of a stack frame profile that adds no custom
  * logic on top of the standard JDI.
  *
+ * @param scalaVirtualMachine The high-level virtual machine containing the
+ *                            stack frame
  * @param stackFrame The reference to the underlying JDI stack frame instance
  * @param index The index of the frame relative to the frame stack
  */
 class PureFrameInfoProfile(
+  val scalaVirtualMachine: ScalaVirtualMachine,
   private val stackFrame: StackFrame,
   val index: Int
 ) extends FrameInfoProfile {
@@ -126,20 +130,23 @@ class PureFrameInfoProfile(
     localVariable: LocalVariable,
     offsetIndex: Int
   ): IndexedVariableInfoProfile = new PureLocalVariableInfoProfile(
+    scalaVirtualMachine,
     this,
     localVariable,
     offsetIndex
   )()
 
   protected def newObjectProfile(objectReference: ObjectReference): ObjectInfoProfile =
-    new PureObjectInfoProfile(objectReference)(threadReference = threadReference)
+    new PureObjectInfoProfile(scalaVirtualMachine, objectReference)(
+      threadReference = threadReference
+    )
 
   protected def newThreadProfile(threadReference: ThreadReference): ThreadInfoProfile =
-    new PureThreadInfoProfile(threadReference)()
+    new PureThreadInfoProfile(scalaVirtualMachine, threadReference)()
 
   protected def newLocationProfile(location: Location): LocationInfoProfile =
-    new PureLocationInfoProfile(location)
+    new PureLocationInfoProfile(scalaVirtualMachine, location)
 
   protected def newValueProfile(value: Value): ValueInfoProfile =
-    new PureValueInfoProfile(value)
+    new PureValueInfoProfile(scalaVirtualMachine, value)
 }

--- a/scala-debugger-api/src/main/scala/org/scaladebugger/api/profiles/pure/info/PureGrabInfoProfile.scala
+++ b/scala-debugger-api/src/main/scala/org/scaladebugger/api/profiles/pure/info/PureGrabInfoProfile.scala
@@ -1,8 +1,9 @@
 package org.scaladebugger.api.profiles.pure.info
 //import acyclic.file
 
-import com.sun.jdi.{ReferenceType, VirtualMachine, ThreadReference}
-import org.scaladebugger.api.profiles.traits.info.{ReferenceTypeInfoProfile, ThreadInfoProfile, GrabInfoProfile}
+import com.sun.jdi.{ReferenceType, ThreadReference, VirtualMachine}
+import org.scaladebugger.api.profiles.traits.info.{GrabInfoProfile, ReferenceTypeInfoProfile, ThreadInfoProfile}
+import org.scaladebugger.api.virtualmachines.ScalaVirtualMachine
 
 import scala.util.{Success, Try}
 
@@ -11,6 +12,7 @@ import scala.util.{Success, Try}
  * and other objects that adds no extra logic on top of the standard JDI.
  */
 trait PureGrabInfoProfile extends GrabInfoProfile {
+  protected val scalaVirtualMachine: ScalaVirtualMachine
   protected val _virtualMachine: VirtualMachine
 
   /**
@@ -51,9 +53,15 @@ trait PureGrabInfoProfile extends GrabInfoProfile {
   }
 
   protected def newThreadProfile(threadReference: ThreadReference): ThreadInfoProfile =
-    new PureThreadInfoProfile(threadReference)(virtualMachine = _virtualMachine)
+    new PureThreadInfoProfile(
+      scalaVirtualMachine,
+      threadReference
+    )(virtualMachine = _virtualMachine)
 
   protected def newReferenceTypeProfile(
     referenceType: ReferenceType
-  ): ReferenceTypeInfoProfile = new PureReferenceTypeInfoProfile(referenceType)
+  ): ReferenceTypeInfoProfile = new PureReferenceTypeInfoProfile(
+    scalaVirtualMachine,
+    referenceType
+  )
 }

--- a/scala-debugger-api/src/main/scala/org/scaladebugger/api/profiles/pure/info/PureLocalVariableInfoProfile.scala
+++ b/scala-debugger-api/src/main/scala/org/scaladebugger/api/profiles/pure/info/PureLocalVariableInfoProfile.scala
@@ -3,6 +3,7 @@ package org.scaladebugger.api.profiles.pure.info
 
 import com.sun.jdi._
 import org.scaladebugger.api.profiles.traits.info.{FrameInfoProfile, IndexedVariableInfoProfile, ValueInfoProfile, VariableInfoProfile}
+import org.scaladebugger.api.virtualmachines.ScalaVirtualMachine
 
 import scala.util.Try
 
@@ -10,6 +11,8 @@ import scala.util.Try
  * Represents a pure implementation of a local variable profile that adds no
  * custom logic on top of the standard JDI.
  *
+ * @param scalaVirtualMachine The high-level virtual machine containing the
+ *                            local variable
  * @param frame The frame associated with the local variable instance
  * @param localVariable The reference to the underlying JDI local variable
  * @param offsetIndex The offset of the variable relative to the frame's
@@ -18,6 +21,7 @@ import scala.util.Try
  *                       the remote JVM
  */
 class PureLocalVariableInfoProfile(
+  val scalaVirtualMachine: ScalaVirtualMachine,
   val frame: FrameInfoProfile,
   private val localVariable: LocalVariable,
   val offsetIndex: Int
@@ -103,5 +107,5 @@ class PureLocalVariableInfoProfile(
   )
 
   protected def newValueProfile(value: Value): ValueInfoProfile =
-    new PureValueInfoProfile(value)
+    new PureValueInfoProfile(scalaVirtualMachine, value)
 }

--- a/scala-debugger-api/src/main/scala/org/scaladebugger/api/profiles/pure/info/PureLocationInfoProfile.scala
+++ b/scala-debugger-api/src/main/scala/org/scaladebugger/api/profiles/pure/info/PureLocationInfoProfile.scala
@@ -2,14 +2,18 @@ package org.scaladebugger.api.profiles.pure.info
 
 import com.sun.jdi.{Location, Method, ReferenceType}
 import org.scaladebugger.api.profiles.traits.info.{LocationInfoProfile, MethodInfoProfile, ReferenceTypeInfoProfile}
+import org.scaladebugger.api.virtualmachines.ScalaVirtualMachine
 
 /**
  * Represents a pure implementation of a location profile that adds no
  * custom logic on top of the standard JDI.
  *
+ * @param scalaVirtualMachine The high-level virtual machine containing the
+ *                            location
  * @param location The reference to the underlying JDI location
  */
 class PureLocationInfoProfile(
+  val scalaVirtualMachine: ScalaVirtualMachine,
   private val location: Location
 ) extends LocationInfoProfile {
   /**
@@ -68,9 +72,10 @@ class PureLocationInfoProfile(
   protected def newReferenceTypeProfile(
     referenceType: ReferenceType
   ): ReferenceTypeInfoProfile = new PureReferenceTypeInfoProfile(
+    scalaVirtualMachine,
     referenceType
   )
 
   protected def newMethodProfile(method: Method): MethodInfoProfile =
-    new PureMethodInfoProfile(method)
+    new PureMethodInfoProfile(scalaVirtualMachine, method)
 }

--- a/scala-debugger-api/src/main/scala/org/scaladebugger/api/profiles/pure/info/PureMethodInfoProfile.scala
+++ b/scala-debugger-api/src/main/scala/org/scaladebugger/api/profiles/pure/info/PureMethodInfoProfile.scala
@@ -3,14 +3,18 @@ package org.scaladebugger.api.profiles.pure.info
 
 import com.sun.jdi.Method
 import org.scaladebugger.api.profiles.traits.info.MethodInfoProfile
+import org.scaladebugger.api.virtualmachines.ScalaVirtualMachine
 
 /**
  * Represents a pure implementation of a method profile that adds no
  * custom logic on top of the standard JDI.
  *
+ * @param scalaVirtualMachine The high-level virtual machine containing the
+ *                            method
  * @param method The reference to the underlying JDI method
  */
 class PureMethodInfoProfile(
+  val scalaVirtualMachine: ScalaVirtualMachine,
   private val method: Method
 ) extends MethodInfoProfile {
   /**

--- a/scala-debugger-api/src/main/scala/org/scaladebugger/api/profiles/pure/info/PureMiscInfoProfile.scala
+++ b/scala-debugger-api/src/main/scala/org/scaladebugger/api/profiles/pure/info/PureMiscInfoProfile.scala
@@ -5,6 +5,7 @@ import com.sun.jdi.ReferenceType
 import org.scaladebugger.api.lowlevel.classes.ClassManager
 import org.scaladebugger.api.lowlevel.utils.JDIHelperMethods
 import org.scaladebugger.api.profiles.traits.info.{MiscInfoProfile, ReferenceTypeInfoProfile}
+import org.scaladebugger.api.virtualmachines.ScalaVirtualMachine
 
 import scala.util.Try
 
@@ -13,6 +14,7 @@ import scala.util.Try
  * on top of the standard JDI.
  */
 trait PureMiscInfoProfile extends MiscInfoProfile with JDIHelperMethods {
+  protected val scalaVirtualMachine: ScalaVirtualMachine
   protected val classManager: ClassManager
 
   /**
@@ -59,6 +61,7 @@ trait PureMiscInfoProfile extends MiscInfoProfile with JDIHelperMethods {
   protected def miscNewReferenceTypeProfile(
     referenceType: ReferenceType
   ): ReferenceTypeInfoProfile = new PureReferenceTypeInfoProfile(
+    scalaVirtualMachine,
     referenceType
   )
 }

--- a/scala-debugger-api/src/main/scala/org/scaladebugger/api/profiles/pure/info/PurePrimitiveInfoProfile.scala
+++ b/scala-debugger-api/src/main/scala/org/scaladebugger/api/profiles/pure/info/PurePrimitiveInfoProfile.scala
@@ -4,17 +4,24 @@ package org.scaladebugger.api.profiles.pure.info
 
 import com.sun.jdi._
 import org.scaladebugger.api.profiles.traits.info.{ArrayInfoProfile, ObjectInfoProfile, PrimitiveInfoProfile, ValueInfoProfile}
+import org.scaladebugger.api.virtualmachines.ScalaVirtualMachine
 
 
 /**
  * Represents a pure implementation of a value profile that adds no custom
  * logic on top of the standard JDI.
  *
+ * @param scalaVirtualMachine The high-level virtual machine containing the
+ *                            primitive
  * @param primitiveValue The reference to the underlying JDI value
  */
 class PurePrimitiveInfoProfile(
+  override val scalaVirtualMachine: ScalaVirtualMachine,
   private val primitiveValue: PrimitiveValue
-) extends PureValueInfoProfile(primitiveValue) with PrimitiveInfoProfile {
+) extends PureValueInfoProfile(
+  scalaVirtualMachine,
+  primitiveValue
+) with PrimitiveInfoProfile {
   /**
    * Returns the JDI representation this profile instance wraps.
    *

--- a/scala-debugger-api/src/main/scala/org/scaladebugger/api/profiles/pure/info/PureReferenceTypeInfoProfile.scala
+++ b/scala-debugger-api/src/main/scala/org/scaladebugger/api/profiles/pure/info/PureReferenceTypeInfoProfile.scala
@@ -2,14 +2,18 @@ package org.scaladebugger.api.profiles.pure.info
 
 import com.sun.jdi._
 import org.scaladebugger.api.profiles.traits.info.{ClassLoaderInfoProfile, ClassObjectInfoProfile, _}
+import org.scaladebugger.api.virtualmachines.ScalaVirtualMachine
 
 /**
  * Represents a pure implementation of a reference type profile that adds no
  * custom logic on top of the standard JDI.
  *
+ * @param scalaVirtualMachine The high-level virtual machine containing the
+ *                            reference type
  * @param referenceType The reference to the underlying JDI reference type
  */
 class PureReferenceTypeInfoProfile(
+  val scalaVirtualMachine: ScalaVirtualMachine,
   private val referenceType: ReferenceType
 ) extends ReferenceTypeInfoProfile {
   private lazy val defaultStratum: String = referenceType.defaultStratum()
@@ -263,20 +267,21 @@ class PureReferenceTypeInfoProfile(
   override def getMinorVersion: Int = referenceType.minorVersion()
 
   protected def newFieldProfile(field: Field): VariableInfoProfile =
-    new PureFieldInfoProfile(null, field)()
+    new PureFieldInfoProfile(scalaVirtualMachine, null, field)()
 
   protected def newMethodProfile(method: Method): MethodInfoProfile =
-    new PureMethodInfoProfile(method)
+    new PureMethodInfoProfile(scalaVirtualMachine, method)
 
   protected def newObjectProfile(objectReference: ObjectReference): ObjectInfoProfile =
-    new PureObjectInfoProfile(objectReference)()
+    new PureObjectInfoProfile(scalaVirtualMachine, objectReference)()
 
   protected def newLocationProfile(location: Location): LocationInfoProfile =
-    new PureLocationInfoProfile(location)
+    new PureLocationInfoProfile(scalaVirtualMachine, location)
 
   protected def newClassObjectProfile(
     classObjectReference: ClassObjectReference
   ): ClassObjectInfoProfile = new PureClassObjectInfoProfile(
+    scalaVirtualMachine,
     classObjectReference
   )(
     referenceType = referenceType
@@ -285,6 +290,7 @@ class PureReferenceTypeInfoProfile(
   protected def newClassLoaderProfile(
     classLoaderReference: ClassLoaderReference
   ): ClassLoaderInfoProfile = new PureClassLoaderInfoProfile(
+    scalaVirtualMachine,
     classLoaderReference
   )(
     referenceType = referenceType
@@ -293,6 +299,7 @@ class PureReferenceTypeInfoProfile(
   protected def newReferenceTypeProfile(
     referenceType: ReferenceType
   ): ReferenceTypeInfoProfile = new PureReferenceTypeInfoProfile(
+    scalaVirtualMachine,
     referenceType
   )
 }

--- a/scala-debugger-api/src/main/scala/org/scaladebugger/api/profiles/pure/info/PureThreadInfoProfile.scala
+++ b/scala-debugger-api/src/main/scala/org/scaladebugger/api/profiles/pure/info/PureThreadInfoProfile.scala
@@ -3,6 +3,7 @@ package org.scaladebugger.api.profiles.pure.info
 
 import com.sun.jdi._
 import org.scaladebugger.api.profiles.traits.info.{FrameInfoProfile, ThreadInfoProfile}
+import org.scaladebugger.api.virtualmachines.ScalaVirtualMachine
 
 import scala.util.Try
 
@@ -10,17 +11,20 @@ import scala.util.Try
  * Represents a pure implementation of a thread profile that adds no
  * custom logic on top of the standard JDI.
  *
+ * @param scalaVirtualMachine The high-level virtual machine containing the
+ *                            thread
  * @param threadReference The reference to the underlying JDI thread
  * @param virtualMachine The virtual machine used to mirror local values on
  *                       the remote JVM
  * @param referenceType The reference type for this thread
  */
 class PureThreadInfoProfile(
+  override val scalaVirtualMachine: ScalaVirtualMachine,
   private val threadReference: ThreadReference
 )(
   private val virtualMachine: VirtualMachine = threadReference.virtualMachine(),
   private val referenceType: ReferenceType = threadReference.referenceType()
-) extends PureObjectInfoProfile(threadReference)(
+) extends PureObjectInfoProfile(scalaVirtualMachine, threadReference)(
   virtualMachine = virtualMachine,
   threadReference = threadReference,
   referenceType = referenceType
@@ -72,5 +76,9 @@ class PureThreadInfoProfile(
   protected def newFrameProfile(
     stackFrame: StackFrame,
     index: Int
-  ): FrameInfoProfile = new PureFrameInfoProfile(stackFrame, index)
+  ): FrameInfoProfile = new PureFrameInfoProfile(
+    scalaVirtualMachine,
+    stackFrame,
+    index
+  )
 }

--- a/scala-debugger-api/src/main/scala/org/scaladebugger/api/profiles/pure/info/PureValueInfoProfile.scala
+++ b/scala-debugger-api/src/main/scala/org/scaladebugger/api/profiles/pure/info/PureValueInfoProfile.scala
@@ -3,6 +3,7 @@ package org.scaladebugger.api.profiles.pure.info
 
 import com.sun.jdi._
 import org.scaladebugger.api.profiles.traits.info.{ArrayInfoProfile, ObjectInfoProfile, PrimitiveInfoProfile, ValueInfoProfile}
+import org.scaladebugger.api.virtualmachines.ScalaVirtualMachine
 
 import scala.util.Try
 
@@ -14,9 +15,12 @@ object PureValueInfoProfile {
  * Represents a pure implementation of a value profile that adds no custom
  * logic on top of the standard JDI.
  *
+ * @param scalaVirtualMachine The high-level virtual machine containing the
+ *                            value
  * @param value The reference to the underlying JDI value
  */
 class PureValueInfoProfile(
+  val scalaVirtualMachine: ScalaVirtualMachine,
   private val value: Value
 ) extends ValueInfoProfile {
   /**
@@ -125,11 +129,11 @@ class PureValueInfoProfile(
   override def isNull: Boolean = value == null
 
   protected def newPrimitiveProfile(primitiveValue: PrimitiveValue): PrimitiveInfoProfile =
-    new PurePrimitiveInfoProfile(primitiveValue)
+    new PurePrimitiveInfoProfile(scalaVirtualMachine, primitiveValue)
 
   protected def newObjectProfile(objectReference: ObjectReference): ObjectInfoProfile =
-    new PureObjectInfoProfile(objectReference)()
+    new PureObjectInfoProfile(scalaVirtualMachine, objectReference)()
 
   protected def newArrayProfile(arrayReference: ArrayReference): ArrayInfoProfile =
-    new PureArrayInfoProfile(arrayReference)()
+    new PureArrayInfoProfile(scalaVirtualMachine, arrayReference)()
 }

--- a/scala-debugger-api/src/main/scala/org/scaladebugger/api/profiles/pure/methods/PureMethodEntryProfile.scala
+++ b/scala-debugger-api/src/main/scala/org/scaladebugger/api/profiles/pure/methods/PureMethodEntryProfile.scala
@@ -1,5 +1,5 @@
 package org.scaladebugger.api.profiles.pure.methods
-import acyclic.file
+//import acyclic.file
 
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.atomic.AtomicInteger

--- a/scala-debugger-api/src/main/scala/org/scaladebugger/api/profiles/pure/methods/PureMethodExitProfile.scala
+++ b/scala-debugger-api/src/main/scala/org/scaladebugger/api/profiles/pure/methods/PureMethodExitProfile.scala
@@ -1,5 +1,5 @@
 package org.scaladebugger.api.profiles.pure.methods
-import acyclic.file
+//import acyclic.file
 
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.atomic.AtomicInteger

--- a/scala-debugger-api/src/main/scala/org/scaladebugger/api/profiles/pure/monitors/PureMonitorContendedEnterProfile.scala
+++ b/scala-debugger-api/src/main/scala/org/scaladebugger/api/profiles/pure/monitors/PureMonitorContendedEnterProfile.scala
@@ -1,5 +1,5 @@
 package org.scaladebugger.api.profiles.pure.monitors
-import acyclic.file
+//import acyclic.file
 
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.atomic.AtomicInteger

--- a/scala-debugger-api/src/main/scala/org/scaladebugger/api/profiles/pure/monitors/PureMonitorContendedEnteredProfile.scala
+++ b/scala-debugger-api/src/main/scala/org/scaladebugger/api/profiles/pure/monitors/PureMonitorContendedEnteredProfile.scala
@@ -1,5 +1,5 @@
 package org.scaladebugger.api.profiles.pure.monitors
-import acyclic.file
+//import acyclic.file
 
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.atomic.AtomicInteger

--- a/scala-debugger-api/src/main/scala/org/scaladebugger/api/profiles/pure/monitors/PureMonitorWaitProfile.scala
+++ b/scala-debugger-api/src/main/scala/org/scaladebugger/api/profiles/pure/monitors/PureMonitorWaitProfile.scala
@@ -1,5 +1,5 @@
 package org.scaladebugger.api.profiles.pure.monitors
-import acyclic.file
+//import acyclic.file
 
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.atomic.AtomicInteger

--- a/scala-debugger-api/src/main/scala/org/scaladebugger/api/profiles/pure/monitors/PureMonitorWaitedProfile.scala
+++ b/scala-debugger-api/src/main/scala/org/scaladebugger/api/profiles/pure/monitors/PureMonitorWaitedProfile.scala
@@ -1,5 +1,5 @@
 package org.scaladebugger.api.profiles.pure.monitors
-import acyclic.file
+//import acyclic.file
 
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.atomic.AtomicInteger

--- a/scala-debugger-api/src/main/scala/org/scaladebugger/api/profiles/pure/steps/PureStepProfile.scala
+++ b/scala-debugger-api/src/main/scala/org/scaladebugger/api/profiles/pure/steps/PureStepProfile.scala
@@ -1,5 +1,5 @@
 package org.scaladebugger.api.profiles.pure.steps
-import acyclic.file
+//import acyclic.file
 
 import com.sun.jdi.ThreadReference
 import com.sun.jdi.event.StepEvent

--- a/scala-debugger-api/src/main/scala/org/scaladebugger/api/profiles/pure/threads/PureThreadDeathProfile.scala
+++ b/scala-debugger-api/src/main/scala/org/scaladebugger/api/profiles/pure/threads/PureThreadDeathProfile.scala
@@ -1,5 +1,5 @@
 package org.scaladebugger.api.profiles.pure.threads
-import acyclic.file
+//import acyclic.file
 
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.atomic.AtomicInteger

--- a/scala-debugger-api/src/main/scala/org/scaladebugger/api/profiles/pure/threads/PureThreadStartProfile.scala
+++ b/scala-debugger-api/src/main/scala/org/scaladebugger/api/profiles/pure/threads/PureThreadStartProfile.scala
@@ -1,5 +1,5 @@
 package org.scaladebugger.api.profiles.pure.threads
-import acyclic.file
+//import acyclic.file
 
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.atomic.AtomicInteger

--- a/scala-debugger-api/src/main/scala/org/scaladebugger/api/profiles/pure/vm/PureVMDeathProfile.scala
+++ b/scala-debugger-api/src/main/scala/org/scaladebugger/api/profiles/pure/vm/PureVMDeathProfile.scala
@@ -1,5 +1,5 @@
 package org.scaladebugger.api.profiles.pure.vm
-import acyclic.file
+//import acyclic.file
 
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.atomic.AtomicInteger

--- a/scala-debugger-api/src/main/scala/org/scaladebugger/api/profiles/pure/vm/PureVMDisconnectProfile.scala
+++ b/scala-debugger-api/src/main/scala/org/scaladebugger/api/profiles/pure/vm/PureVMDisconnectProfile.scala
@@ -1,5 +1,5 @@
 package org.scaladebugger.api.profiles.pure.vm
-import acyclic.file
+//import acyclic.file
 
 import com.sun.jdi.event.VMDisconnectEvent
 import org.scaladebugger.api.lowlevel.JDIArgument

--- a/scala-debugger-api/src/main/scala/org/scaladebugger/api/profiles/pure/vm/PureVMStartProfile.scala
+++ b/scala-debugger-api/src/main/scala/org/scaladebugger/api/profiles/pure/vm/PureVMStartProfile.scala
@@ -1,5 +1,5 @@
 package org.scaladebugger.api.profiles.pure.vm
-import acyclic.file
+//import acyclic.file
 
 import com.sun.jdi.event.VMStartEvent
 import org.scaladebugger.api.lowlevel.JDIArgument

--- a/scala-debugger-api/src/main/scala/org/scaladebugger/api/profiles/pure/watchpoints/PureAccessWatchpointProfile.scala
+++ b/scala-debugger-api/src/main/scala/org/scaladebugger/api/profiles/pure/watchpoints/PureAccessWatchpointProfile.scala
@@ -1,5 +1,5 @@
 package org.scaladebugger.api.profiles.pure.watchpoints
-import acyclic.file
+//import acyclic.file
 
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.atomic.AtomicInteger

--- a/scala-debugger-api/src/main/scala/org/scaladebugger/api/profiles/pure/watchpoints/PureModificationWatchpointProfile.scala
+++ b/scala-debugger-api/src/main/scala/org/scaladebugger/api/profiles/pure/watchpoints/PureModificationWatchpointProfile.scala
@@ -1,5 +1,5 @@
 package org.scaladebugger.api.profiles.pure.watchpoints
-import acyclic.file
+//import acyclic.file
 
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.atomic.AtomicInteger

--- a/scala-debugger-api/src/main/scala/org/scaladebugger/api/profiles/swappable/SwappableDebugProfile.scala
+++ b/scala-debugger-api/src/main/scala/org/scaladebugger/api/profiles/swappable/SwappableDebugProfile.scala
@@ -1,5 +1,5 @@
 package org.scaladebugger.api.profiles.swappable
-import acyclic.file
+//import acyclic.file
 
 import org.scaladebugger.api.profiles.ProfileManager
 import org.scaladebugger.api.profiles.swappable.breakpoints.SwappableBreakpointProfile

--- a/scala-debugger-api/src/main/scala/org/scaladebugger/api/profiles/swappable/breakpoints/SwappableBreakpointProfile.scala
+++ b/scala-debugger-api/src/main/scala/org/scaladebugger/api/profiles/swappable/breakpoints/SwappableBreakpointProfile.scala
@@ -1,5 +1,5 @@
 package org.scaladebugger.api.profiles.swappable.breakpoints
-import acyclic.file
+//import acyclic.file
 
 import org.scaladebugger.api.lowlevel.JDIArgument
 import org.scaladebugger.api.lowlevel.breakpoints.BreakpointRequestInfo

--- a/scala-debugger-api/src/main/scala/org/scaladebugger/api/profiles/swappable/classes/SwappableClassPrepareProfile.scala
+++ b/scala-debugger-api/src/main/scala/org/scaladebugger/api/profiles/swappable/classes/SwappableClassPrepareProfile.scala
@@ -1,5 +1,5 @@
 package org.scaladebugger.api.profiles.swappable.classes
-import acyclic.file
+//import acyclic.file
 
 import org.scaladebugger.api.lowlevel.JDIArgument
 import org.scaladebugger.api.lowlevel.classes.ClassPrepareRequestInfo

--- a/scala-debugger-api/src/main/scala/org/scaladebugger/api/profiles/swappable/classes/SwappableClassUnloadProfile.scala
+++ b/scala-debugger-api/src/main/scala/org/scaladebugger/api/profiles/swappable/classes/SwappableClassUnloadProfile.scala
@@ -1,5 +1,5 @@
 package org.scaladebugger.api.profiles.swappable.classes
-import acyclic.file
+//import acyclic.file
 
 import org.scaladebugger.api.lowlevel.JDIArgument
 import org.scaladebugger.api.lowlevel.classes.ClassUnloadRequestInfo

--- a/scala-debugger-api/src/main/scala/org/scaladebugger/api/profiles/swappable/events/SwappableEventProfile.scala
+++ b/scala-debugger-api/src/main/scala/org/scaladebugger/api/profiles/swappable/events/SwappableEventProfile.scala
@@ -1,5 +1,5 @@
 package org.scaladebugger.api.profiles.swappable.events
-import acyclic.file
+//import acyclic.file
 
 import org.scaladebugger.api.lowlevel.JDIArgument
 import org.scaladebugger.api.lowlevel.events.EventHandlerInfo

--- a/scala-debugger-api/src/main/scala/org/scaladebugger/api/profiles/swappable/exceptions/SwappableExceptionProfile.scala
+++ b/scala-debugger-api/src/main/scala/org/scaladebugger/api/profiles/swappable/exceptions/SwappableExceptionProfile.scala
@@ -1,5 +1,5 @@
 package org.scaladebugger.api.profiles.swappable.exceptions
-import acyclic.file
+//import acyclic.file
 
 import org.scaladebugger.api.lowlevel.JDIArgument
 import org.scaladebugger.api.lowlevel.exceptions.ExceptionRequestInfo

--- a/scala-debugger-api/src/main/scala/org/scaladebugger/api/profiles/swappable/info/SwappableGrabInfoProfile.scala
+++ b/scala-debugger-api/src/main/scala/org/scaladebugger/api/profiles/swappable/info/SwappableGrabInfoProfile.scala
@@ -1,5 +1,5 @@
 package org.scaladebugger.api.profiles.swappable.info
-import acyclic.file
+//import acyclic.file
 
 import com.sun.jdi.ThreadReference
 import org.scaladebugger.api.profiles.swappable.SwappableDebugProfileManagement

--- a/scala-debugger-api/src/main/scala/org/scaladebugger/api/profiles/swappable/info/SwappableMiscInfoProfile.scala
+++ b/scala-debugger-api/src/main/scala/org/scaladebugger/api/profiles/swappable/info/SwappableMiscInfoProfile.scala
@@ -1,5 +1,5 @@
 package org.scaladebugger.api.profiles.swappable.info
-import acyclic.file
+//import acyclic.file
 import org.scaladebugger.api.profiles.swappable.SwappableDebugProfileManagement
 
 import org.scaladebugger.api.profiles.traits.info.MiscInfoProfile

--- a/scala-debugger-api/src/main/scala/org/scaladebugger/api/profiles/swappable/methods/SwappableMethodEntryProfile.scala
+++ b/scala-debugger-api/src/main/scala/org/scaladebugger/api/profiles/swappable/methods/SwappableMethodEntryProfile.scala
@@ -1,5 +1,5 @@
 package org.scaladebugger.api.profiles.swappable.methods
-import acyclic.file
+//import acyclic.file
 
 import org.scaladebugger.api.lowlevel.JDIArgument
 import org.scaladebugger.api.lowlevel.methods.MethodEntryRequestInfo

--- a/scala-debugger-api/src/main/scala/org/scaladebugger/api/profiles/swappable/methods/SwappableMethodExitProfile.scala
+++ b/scala-debugger-api/src/main/scala/org/scaladebugger/api/profiles/swappable/methods/SwappableMethodExitProfile.scala
@@ -1,5 +1,5 @@
 package org.scaladebugger.api.profiles.swappable.methods
-import acyclic.file
+//import acyclic.file
 
 import org.scaladebugger.api.lowlevel.JDIArgument
 import org.scaladebugger.api.lowlevel.methods.MethodExitRequestInfo

--- a/scala-debugger-api/src/main/scala/org/scaladebugger/api/profiles/swappable/monitors/SwappableMonitorContendedEnterProfile.scala
+++ b/scala-debugger-api/src/main/scala/org/scaladebugger/api/profiles/swappable/monitors/SwappableMonitorContendedEnterProfile.scala
@@ -1,5 +1,5 @@
 package org.scaladebugger.api.profiles.swappable.monitors
-import acyclic.file
+//import acyclic.file
 
 import org.scaladebugger.api.lowlevel.JDIArgument
 import org.scaladebugger.api.lowlevel.monitors.MonitorContendedEnterRequestInfo

--- a/scala-debugger-api/src/main/scala/org/scaladebugger/api/profiles/swappable/monitors/SwappableMonitorContendedEnteredProfile.scala
+++ b/scala-debugger-api/src/main/scala/org/scaladebugger/api/profiles/swappable/monitors/SwappableMonitorContendedEnteredProfile.scala
@@ -1,5 +1,5 @@
 package org.scaladebugger.api.profiles.swappable.monitors
-import acyclic.file
+//import acyclic.file
 
 import org.scaladebugger.api.lowlevel.JDIArgument
 import org.scaladebugger.api.lowlevel.monitors.MonitorContendedEnteredRequestInfo

--- a/scala-debugger-api/src/main/scala/org/scaladebugger/api/profiles/swappable/monitors/SwappableMonitorWaitProfile.scala
+++ b/scala-debugger-api/src/main/scala/org/scaladebugger/api/profiles/swappable/monitors/SwappableMonitorWaitProfile.scala
@@ -1,5 +1,5 @@
 package org.scaladebugger.api.profiles.swappable.monitors
-import acyclic.file
+//import acyclic.file
 
 import org.scaladebugger.api.lowlevel.JDIArgument
 import org.scaladebugger.api.lowlevel.monitors.MonitorWaitRequestInfo

--- a/scala-debugger-api/src/main/scala/org/scaladebugger/api/profiles/swappable/monitors/SwappableMonitorWaitedProfile.scala
+++ b/scala-debugger-api/src/main/scala/org/scaladebugger/api/profiles/swappable/monitors/SwappableMonitorWaitedProfile.scala
@@ -1,5 +1,5 @@
 package org.scaladebugger.api.profiles.swappable.monitors
-import acyclic.file
+//import acyclic.file
 
 import org.scaladebugger.api.lowlevel.JDIArgument
 import org.scaladebugger.api.lowlevel.monitors.MonitorWaitedRequestInfo

--- a/scala-debugger-api/src/main/scala/org/scaladebugger/api/profiles/swappable/steps/SwappableStepProfile.scala
+++ b/scala-debugger-api/src/main/scala/org/scaladebugger/api/profiles/swappable/steps/SwappableStepProfile.scala
@@ -1,5 +1,5 @@
 package org.scaladebugger.api.profiles.swappable.steps
-import acyclic.file
+//import acyclic.file
 
 import com.sun.jdi.event.StepEvent
 import org.scaladebugger.api.lowlevel.JDIArgument

--- a/scala-debugger-api/src/main/scala/org/scaladebugger/api/profiles/swappable/threads/SwappableThreadDeathProfile.scala
+++ b/scala-debugger-api/src/main/scala/org/scaladebugger/api/profiles/swappable/threads/SwappableThreadDeathProfile.scala
@@ -1,5 +1,5 @@
 package org.scaladebugger.api.profiles.swappable.threads
-import acyclic.file
+//import acyclic.file
 
 import org.scaladebugger.api.lowlevel.JDIArgument
 import org.scaladebugger.api.lowlevel.threads.ThreadDeathRequestInfo

--- a/scala-debugger-api/src/main/scala/org/scaladebugger/api/profiles/swappable/threads/SwappableThreadStartProfile.scala
+++ b/scala-debugger-api/src/main/scala/org/scaladebugger/api/profiles/swappable/threads/SwappableThreadStartProfile.scala
@@ -1,5 +1,5 @@
 package org.scaladebugger.api.profiles.swappable.threads
-import acyclic.file
+//import acyclic.file
 
 import org.scaladebugger.api.lowlevel.JDIArgument
 import org.scaladebugger.api.lowlevel.threads.ThreadStartRequestInfo

--- a/scala-debugger-api/src/main/scala/org/scaladebugger/api/profiles/swappable/vm/SwappableVMDeathProfile.scala
+++ b/scala-debugger-api/src/main/scala/org/scaladebugger/api/profiles/swappable/vm/SwappableVMDeathProfile.scala
@@ -1,5 +1,5 @@
 package org.scaladebugger.api.profiles.swappable.vm
-import acyclic.file
+//import acyclic.file
 
 import org.scaladebugger.api.lowlevel.JDIArgument
 import org.scaladebugger.api.lowlevel.vm.VMDeathRequestInfo

--- a/scala-debugger-api/src/main/scala/org/scaladebugger/api/profiles/swappable/vm/SwappableVMDisconnectProfile.scala
+++ b/scala-debugger-api/src/main/scala/org/scaladebugger/api/profiles/swappable/vm/SwappableVMDisconnectProfile.scala
@@ -1,5 +1,5 @@
 package org.scaladebugger.api.profiles.swappable.vm
-import acyclic.file
+//import acyclic.file
 
 import org.scaladebugger.api.lowlevel.JDIArgument
 import org.scaladebugger.api.pipelines.Pipeline.IdentityPipeline

--- a/scala-debugger-api/src/main/scala/org/scaladebugger/api/profiles/swappable/vm/SwappableVMStartProfile.scala
+++ b/scala-debugger-api/src/main/scala/org/scaladebugger/api/profiles/swappable/vm/SwappableVMStartProfile.scala
@@ -1,5 +1,5 @@
 package org.scaladebugger.api.profiles.swappable.vm
-import acyclic.file
+//import acyclic.file
 
 import org.scaladebugger.api.lowlevel.JDIArgument
 import org.scaladebugger.api.pipelines.Pipeline.IdentityPipeline

--- a/scala-debugger-api/src/main/scala/org/scaladebugger/api/profiles/swappable/watchpoints/SwappableAccessWatchpointProfile.scala
+++ b/scala-debugger-api/src/main/scala/org/scaladebugger/api/profiles/swappable/watchpoints/SwappableAccessWatchpointProfile.scala
@@ -1,5 +1,5 @@
 package org.scaladebugger.api.profiles.swappable.watchpoints
-import acyclic.file
+//import acyclic.file
 
 import org.scaladebugger.api.lowlevel.JDIArgument
 import org.scaladebugger.api.lowlevel.watchpoints.AccessWatchpointRequestInfo

--- a/scala-debugger-api/src/main/scala/org/scaladebugger/api/profiles/swappable/watchpoints/SwappableModificationWatchpointProfile.scala
+++ b/scala-debugger-api/src/main/scala/org/scaladebugger/api/profiles/swappable/watchpoints/SwappableModificationWatchpointProfile.scala
@@ -1,5 +1,5 @@
 package org.scaladebugger.api.profiles.swappable.watchpoints
-import acyclic.file
+//import acyclic.file
 
 import org.scaladebugger.api.lowlevel.JDIArgument
 import org.scaladebugger.api.lowlevel.watchpoints.ModificationWatchpointRequestInfo

--- a/scala-debugger-api/src/main/scala/org/scaladebugger/api/profiles/traits/DebugProfile.scala
+++ b/scala-debugger-api/src/main/scala/org/scaladebugger/api/profiles/traits/DebugProfile.scala
@@ -1,5 +1,5 @@
 package org.scaladebugger.api.profiles.traits
-import acyclic.file
+//import acyclic.file
 
 import org.scaladebugger.api.profiles.traits.breakpoints.BreakpointProfile
 import org.scaladebugger.api.profiles.traits.classes.{ClassPrepareProfile, ClassUnloadProfile}

--- a/scala-debugger-api/src/main/scala/org/scaladebugger/api/profiles/traits/ManagerContainerDebugProfile.scala
+++ b/scala-debugger-api/src/main/scala/org/scaladebugger/api/profiles/traits/ManagerContainerDebugProfile.scala
@@ -1,5 +1,5 @@
 package org.scaladebugger.api.profiles.traits
-import acyclic.file
+//import acyclic.file
 
 import org.scaladebugger.api.lowlevel.ManagerContainer
 

--- a/scala-debugger-api/src/main/scala/org/scaladebugger/api/profiles/traits/breakpoints/BreakpointProfile.scala
+++ b/scala-debugger-api/src/main/scala/org/scaladebugger/api/profiles/traits/breakpoints/BreakpointProfile.scala
@@ -1,5 +1,5 @@
 package org.scaladebugger.api.profiles.traits.breakpoints
-import acyclic.file
+//import acyclic.file
 
 import com.sun.jdi.event.BreakpointEvent
 import org.scaladebugger.api.lowlevel.JDIArgument

--- a/scala-debugger-api/src/main/scala/org/scaladebugger/api/profiles/traits/classes/ClassPrepareProfile.scala
+++ b/scala-debugger-api/src/main/scala/org/scaladebugger/api/profiles/traits/classes/ClassPrepareProfile.scala
@@ -1,5 +1,5 @@
 package org.scaladebugger.api.profiles.traits.classes
-import acyclic.file
+//import acyclic.file
 
 import com.sun.jdi.event.ClassPrepareEvent
 import org.scaladebugger.api.lowlevel.JDIArgument

--- a/scala-debugger-api/src/main/scala/org/scaladebugger/api/profiles/traits/classes/ClassUnloadProfile.scala
+++ b/scala-debugger-api/src/main/scala/org/scaladebugger/api/profiles/traits/classes/ClassUnloadProfile.scala
@@ -1,5 +1,5 @@
 package org.scaladebugger.api.profiles.traits.classes
-import acyclic.file
+//import acyclic.file
 
 import com.sun.jdi.event.ClassUnloadEvent
 import org.scaladebugger.api.lowlevel.JDIArgument

--- a/scala-debugger-api/src/main/scala/org/scaladebugger/api/profiles/traits/events/EventProfile.scala
+++ b/scala-debugger-api/src/main/scala/org/scaladebugger/api/profiles/traits/events/EventProfile.scala
@@ -1,5 +1,5 @@
 package org.scaladebugger.api.profiles.traits.events
-import acyclic.file
+//import acyclic.file
 
 import com.sun.jdi.event.Event
 import org.scaladebugger.api.lowlevel.JDIArgument

--- a/scala-debugger-api/src/main/scala/org/scaladebugger/api/profiles/traits/exceptions/ExceptionProfile.scala
+++ b/scala-debugger-api/src/main/scala/org/scaladebugger/api/profiles/traits/exceptions/ExceptionProfile.scala
@@ -1,5 +1,5 @@
 package org.scaladebugger.api.profiles.traits.exceptions
-import acyclic.file
+//import acyclic.file
 
 import com.sun.jdi.event.ExceptionEvent
 import org.scaladebugger.api.lowlevel.JDIArgument

--- a/scala-debugger-api/src/main/scala/org/scaladebugger/api/profiles/traits/info/CommonInfoProfile.scala
+++ b/scala-debugger-api/src/main/scala/org/scaladebugger/api/profiles/traits/info/CommonInfoProfile.scala
@@ -1,11 +1,19 @@
 package org.scaladebugger.api.profiles.traits.info
 
 import com.sun.jdi.Mirror
+import org.scaladebugger.api.virtualmachines.ScalaVirtualMachine
 
 /**
  * Represents common methods between information-gathering profiles.
  */
 trait CommonInfoProfile {
+  /**
+   * Returns the Scala virtual machine containing this instance.
+   *
+   * @return The Scala virtual machine instance
+   */
+  def scalaVirtualMachine: ScalaVirtualMachine
+
   /**
    * Returns the JDI representation this profile instance wraps.
    *

--- a/scala-debugger-api/src/main/scala/org/scaladebugger/api/profiles/traits/methods/MethodEntryProfile.scala
+++ b/scala-debugger-api/src/main/scala/org/scaladebugger/api/profiles/traits/methods/MethodEntryProfile.scala
@@ -1,5 +1,5 @@
 package org.scaladebugger.api.profiles.traits.methods
-import acyclic.file
+//import acyclic.file
 
 import com.sun.jdi.event.MethodEntryEvent
 import org.scaladebugger.api.lowlevel.JDIArgument

--- a/scala-debugger-api/src/main/scala/org/scaladebugger/api/profiles/traits/methods/MethodExitProfile.scala
+++ b/scala-debugger-api/src/main/scala/org/scaladebugger/api/profiles/traits/methods/MethodExitProfile.scala
@@ -1,5 +1,5 @@
 package org.scaladebugger.api.profiles.traits.methods
-import acyclic.file
+//import acyclic.file
 
 import com.sun.jdi.event.MethodExitEvent
 import org.scaladebugger.api.lowlevel.JDIArgument

--- a/scala-debugger-api/src/main/scala/org/scaladebugger/api/profiles/traits/monitors/MonitorContendedEnterProfile.scala
+++ b/scala-debugger-api/src/main/scala/org/scaladebugger/api/profiles/traits/monitors/MonitorContendedEnterProfile.scala
@@ -1,5 +1,5 @@
 package org.scaladebugger.api.profiles.traits.monitors
-import acyclic.file
+//import acyclic.file
 
 import com.sun.jdi.event.MonitorContendedEnterEvent
 import org.scaladebugger.api.lowlevel.JDIArgument

--- a/scala-debugger-api/src/main/scala/org/scaladebugger/api/profiles/traits/monitors/MonitorContendedEnteredProfile.scala
+++ b/scala-debugger-api/src/main/scala/org/scaladebugger/api/profiles/traits/monitors/MonitorContendedEnteredProfile.scala
@@ -1,5 +1,5 @@
 package org.scaladebugger.api.profiles.traits.monitors
-import acyclic.file
+//import acyclic.file
 
 import com.sun.jdi.event.MonitorContendedEnteredEvent
 import org.scaladebugger.api.lowlevel.JDIArgument

--- a/scala-debugger-api/src/main/scala/org/scaladebugger/api/profiles/traits/monitors/MonitorWaitProfile.scala
+++ b/scala-debugger-api/src/main/scala/org/scaladebugger/api/profiles/traits/monitors/MonitorWaitProfile.scala
@@ -1,5 +1,5 @@
 package org.scaladebugger.api.profiles.traits.monitors
-import acyclic.file
+//import acyclic.file
 
 import com.sun.jdi.event.MonitorWaitEvent
 import org.scaladebugger.api.lowlevel.JDIArgument

--- a/scala-debugger-api/src/main/scala/org/scaladebugger/api/profiles/traits/monitors/MonitorWaitedProfile.scala
+++ b/scala-debugger-api/src/main/scala/org/scaladebugger/api/profiles/traits/monitors/MonitorWaitedProfile.scala
@@ -1,5 +1,5 @@
 package org.scaladebugger.api.profiles.traits.monitors
-import acyclic.file
+//import acyclic.file
 
 import com.sun.jdi.event.MonitorWaitedEvent
 import org.scaladebugger.api.lowlevel.JDIArgument

--- a/scala-debugger-api/src/main/scala/org/scaladebugger/api/profiles/traits/steps/StepProfile.scala
+++ b/scala-debugger-api/src/main/scala/org/scaladebugger/api/profiles/traits/steps/StepProfile.scala
@@ -1,5 +1,5 @@
 package org.scaladebugger.api.profiles.traits.steps
-import acyclic.file
+//import acyclic.file
 
 import com.sun.jdi.event.StepEvent
 import org.scaladebugger.api.lowlevel.JDIArgument

--- a/scala-debugger-api/src/main/scala/org/scaladebugger/api/profiles/traits/threads/ThreadDeathProfile.scala
+++ b/scala-debugger-api/src/main/scala/org/scaladebugger/api/profiles/traits/threads/ThreadDeathProfile.scala
@@ -1,5 +1,5 @@
 package org.scaladebugger.api.profiles.traits.threads
-import acyclic.file
+//import acyclic.file
 
 import com.sun.jdi.event.ThreadDeathEvent
 import org.scaladebugger.api.lowlevel.JDIArgument

--- a/scala-debugger-api/src/main/scala/org/scaladebugger/api/profiles/traits/threads/ThreadStartProfile.scala
+++ b/scala-debugger-api/src/main/scala/org/scaladebugger/api/profiles/traits/threads/ThreadStartProfile.scala
@@ -1,5 +1,5 @@
 package org.scaladebugger.api.profiles.traits.threads
-import acyclic.file
+//import acyclic.file
 
 import com.sun.jdi.event.ThreadStartEvent
 import org.scaladebugger.api.lowlevel.JDIArgument

--- a/scala-debugger-api/src/main/scala/org/scaladebugger/api/profiles/traits/vm/VMDeathProfile.scala
+++ b/scala-debugger-api/src/main/scala/org/scaladebugger/api/profiles/traits/vm/VMDeathProfile.scala
@@ -1,5 +1,5 @@
 package org.scaladebugger.api.profiles.traits.vm
-import acyclic.file
+//import acyclic.file
 
 import com.sun.jdi.event.VMDeathEvent
 import org.scaladebugger.api.lowlevel.JDIArgument

--- a/scala-debugger-api/src/main/scala/org/scaladebugger/api/profiles/traits/vm/VMDisconnectProfile.scala
+++ b/scala-debugger-api/src/main/scala/org/scaladebugger/api/profiles/traits/vm/VMDisconnectProfile.scala
@@ -1,5 +1,5 @@
 package org.scaladebugger.api.profiles.traits.vm
-import acyclic.file
+//import acyclic.file
 
 import com.sun.jdi.event.VMDisconnectEvent
 import org.scaladebugger.api.lowlevel.JDIArgument

--- a/scala-debugger-api/src/main/scala/org/scaladebugger/api/profiles/traits/vm/VMStartProfile.scala
+++ b/scala-debugger-api/src/main/scala/org/scaladebugger/api/profiles/traits/vm/VMStartProfile.scala
@@ -1,5 +1,5 @@
 package org.scaladebugger.api.profiles.traits.vm
-import acyclic.file
+//import acyclic.file
 
 import com.sun.jdi.event.VMStartEvent
 import org.scaladebugger.api.lowlevel.JDIArgument

--- a/scala-debugger-api/src/main/scala/org/scaladebugger/api/profiles/traits/watchpoints/AccessWatchpointProfile.scala
+++ b/scala-debugger-api/src/main/scala/org/scaladebugger/api/profiles/traits/watchpoints/AccessWatchpointProfile.scala
@@ -1,5 +1,5 @@
 package org.scaladebugger.api.profiles.traits.watchpoints
-import acyclic.file
+//import acyclic.file
 
 import com.sun.jdi.event.AccessWatchpointEvent
 import org.scaladebugger.api.lowlevel.JDIArgument

--- a/scala-debugger-api/src/main/scala/org/scaladebugger/api/profiles/traits/watchpoints/ModificationWatchpointProfile.scala
+++ b/scala-debugger-api/src/main/scala/org/scaladebugger/api/profiles/traits/watchpoints/ModificationWatchpointProfile.scala
@@ -1,5 +1,5 @@
 package org.scaladebugger.api.profiles.traits.watchpoints
-import acyclic.file
+//import acyclic.file
 
 import com.sun.jdi.event.ModificationWatchpointEvent
 import org.scaladebugger.api.lowlevel.JDIArgument

--- a/scala-debugger-api/src/main/scala/org/scaladebugger/api/virtualmachines/DummyScalaVirtualMachine.scala
+++ b/scala-debugger-api/src/main/scala/org/scaladebugger/api/virtualmachines/DummyScalaVirtualMachine.scala
@@ -1,5 +1,5 @@
 package org.scaladebugger.api.virtualmachines
-import acyclic.file
+//import acyclic.file
 
 import com.sun.jdi._
 import org.scaladebugger.api.lowlevel.ManagerContainer
@@ -32,6 +32,12 @@ class DummyScalaVirtualMachine(
    * @return True if started, otherwise false
    */
   override def isStarted: Boolean = false
+
+  /**
+   * Represents the cache of objects available on the virtual machine. This
+   * is unused by the dummy virtual machine.
+   */
+  override lazy val cache: ObjectCache = new ObjectCache
 
   /**
    * A unique id assigned to the Scala virtual machine on the client (library)

--- a/scala-debugger-api/src/main/scala/org/scaladebugger/api/virtualmachines/ObjectCache.scala
+++ b/scala-debugger-api/src/main/scala/org/scaladebugger/api/virtualmachines/ObjectCache.scala
@@ -1,0 +1,98 @@
+package org.scaladebugger.api.virtualmachines
+
+import java.util.concurrent.ConcurrentHashMap
+
+import org.scaladebugger.api.profiles.traits.info.ObjectInfoProfile
+
+import scala.collection.JavaConverters._
+import scala.util.Try
+
+import ObjectCache._
+
+object ObjectCache {
+  type CacheId = Long
+  type CacheValue = ObjectInfoProfile
+}
+
+/**
+ * Represents a standard cache for objects originating from a virtual machine.
+ *
+ * @param internalCache Contains the collection of objects by their unique ids
+ */
+class ObjectCache(
+  private val internalCache: collection.mutable.Map[CacheId, CacheValue] =
+    new ConcurrentHashMap[CacheId, CacheValue]().asScala
+) {
+  /**
+   * Saves an object into the cache.
+   *
+   * @param cacheValue The object to save
+   * @return Some object id if the object was saved, otherwise None
+   */
+  def save(cacheValue: CacheValue): Option[CacheId] = {
+    val cacheId = Try(cacheValue.uniqueId)
+    cacheId.foreach(internalCache.put(_, cacheValue))
+    cacheId.toOption
+  }
+
+  /**
+   * Loads an object from the cache.
+   *
+   * @param cacheId The id of the object to load
+   * @return Some object if the object was cached and is still valid,
+   *         otherwise None
+   */
+  def load(cacheId: CacheId): Option[CacheValue] = {
+    val cacheValue = internalCache.get(cacheId)
+    cacheValue.map(isValid).flatMap {
+      case true   => cacheValue
+      case false  => remove(cacheId); None
+    }
+  }
+
+  /**
+   * Returns whether or not the cache has an object with the specified id.
+   *
+   * @return True if the cache has the object, otherwise false
+   */
+  def has(cacheId: CacheId): Boolean = internalCache.contains(cacheId)
+
+  /**
+   * Returns whether or not the cache has the specified object.
+   *
+   * @return True if the cache has the object, otherwise false
+   */
+  def has(cacheValue: CacheValue): Boolean =
+    Try(has(cacheValue.uniqueId)).getOrElse(false)
+
+  /**
+   * Removes an object from the cache.
+   *
+   * @param cacheId The id of the object to remove
+   * @return Some object if the object existed and was removed, otherwise None
+   */
+  def remove(cacheId: CacheId): Option[CacheValue] = {
+    internalCache.remove(cacheId)
+  }
+
+  /**
+   * Removes all objects in the cache.
+   */
+  def clear(): Unit = {
+    internalCache.clear()
+  }
+
+  /**
+   * Indicates whether or not the cached object is still valid on the remote
+   * JVM.
+   *
+   * @param cacheValue The cached object to check
+   * @return True if valid (on remote JVM), otherwise false
+   */
+  private def isValid(cacheValue: CacheValue): Boolean = {
+    // Check if garbage collected (failures to check should also throw out
+    // the cached object)
+    val exists = !Try(cacheValue.toJdiInstance.isCollected).getOrElse(true)
+    exists
+  }
+}

--- a/scala-debugger-api/src/main/scala/org/scaladebugger/api/virtualmachines/ScalaVirtualMachine.scala
+++ b/scala-debugger-api/src/main/scala/org/scaladebugger/api/virtualmachines/ScalaVirtualMachine.scala
@@ -1,5 +1,5 @@
 package org.scaladebugger.api.virtualmachines
-import acyclic.file
+//import acyclic.file
 
 import com.sun.jdi._
 import org.scaladebugger.api.lowlevel.ManagerContainer
@@ -24,6 +24,13 @@ trait ScalaVirtualMachine extends SwappableDebugProfile with ProfileManager {
    * @return True if started, otherwise false
    */
   def isStarted: Boolean
+
+  /**
+   * Represents the cache of objects available on the virtual machine.
+   * Caching is done manually, so this cache is not populated as objects are
+   * created on the virtual machine.
+   */
+  val cache: ObjectCache
 
   /**
    * Represents the collection of low-level APIs for the virtual machine.

--- a/scala-debugger-api/src/main/scala/org/scaladebugger/api/virtualmachines/StandardScalaVirtualMachine.scala
+++ b/scala-debugger-api/src/main/scala/org/scaladebugger/api/virtualmachines/StandardScalaVirtualMachine.scala
@@ -1,5 +1,5 @@
 package org.scaladebugger.api.virtualmachines
-import acyclic.file
+//import acyclic.file
 
 import java.util.concurrent.atomic.AtomicBoolean
 
@@ -62,6 +62,13 @@ class StandardScalaVirtualMachine(
     autoStartEventManager = false
   )
 
+  /**
+   * Represents the cache of objects available on the virtual machine.
+   * Caching is done manually, so this cache is not populated as objects are
+   * created on the virtual machine.
+   */
+  override lazy val cache: ObjectCache = new ObjectCache
+
   /** Represents the collection of low-level APIs for the virtual machine. */
   override lazy val lowlevel = newManagerContainer(loopingTaskRunner)
 
@@ -115,7 +122,7 @@ class StandardScalaVirtualMachine(
   private def registerStandardProfiles(): Unit = {
     this.register(
       PureDebugProfile.Name,
-      new PureDebugProfile(_virtualMachine, lowlevel)
+      new PureDebugProfile(this, lowlevel)(_virtualMachine)
     )
   }
 

--- a/scala-debugger-api/src/test/scala/org/scaladebugger/api/dsl/info/FrameInfoDSLWrapperSpec.scala
+++ b/scala-debugger-api/src/test/scala/org/scaladebugger/api/dsl/info/FrameInfoDSLWrapperSpec.scala
@@ -2,6 +2,7 @@ package org.scaladebugger.api.dsl.info
 
 import com.sun.jdi.StackFrame
 import org.scaladebugger.api.profiles.traits.info._
+import org.scaladebugger.api.virtualmachines.ScalaVirtualMachine
 import org.scalamock.scalatest.MockFactory
 import org.scalatest.{FunSpec, Matchers, ParallelTestExecution}
 
@@ -227,6 +228,7 @@ class FrameInfoDSLWrapperSpec extends FunSpec with Matchers
     }
   }
 
+  private val mockScalaVirtualMachineFunction = mockFunction[ScalaVirtualMachine]
   private val mockIndexFunction = mockFunction[Int]
   private val mockTryGetThisObjectFunction = mockFunction[Try[ObjectInfoProfile]]
   private val mockGetThisObjectFunction = mockFunction[ObjectInfoProfile]
@@ -251,6 +253,7 @@ class FrameInfoDSLWrapperSpec extends FunSpec with Matchers
   private val mockToJdiInstanceFunction = mockFunction[StackFrame]
 
   private class TestFrameInfoProfile extends FrameInfoProfile {
+    override def scalaVirtualMachine: ScalaVirtualMachine = mockScalaVirtualMachineFunction()
     override def index: Int = mockIndexFunction()
     override def tryGetThisObject: Try[ObjectInfoProfile] = mockTryGetThisObjectFunction()
     override def getThisObject: ObjectInfoProfile = mockGetThisObjectFunction()

--- a/scala-debugger-api/src/test/scala/org/scaladebugger/api/dsl/info/ObjectInfoDSLWrapperSpec.scala
+++ b/scala-debugger-api/src/test/scala/org/scaladebugger/api/dsl/info/ObjectInfoDSLWrapperSpec.scala
@@ -1,0 +1,97 @@
+package org.scaladebugger.api.dsl.info
+
+import com.sun.jdi.{ThreadReference, VirtualMachine}
+import org.scaladebugger.api.lowlevel.ManagerContainer
+import org.scaladebugger.api.profiles.ProfileManager
+import org.scaladebugger.api.profiles.traits.DebugProfile
+import org.scaladebugger.api.profiles.traits.info.{ObjectInfoProfile, ThreadInfoProfile}
+import org.scaladebugger.api.virtualmachines.{ObjectCache, ScalaVirtualMachine}
+import org.scalamock.scalatest.MockFactory
+import org.scalatest.{FunSpec, Matchers, ParallelTestExecution}
+
+import scala.util.Success
+
+class ObjectInfoDSLWrapperSpec extends FunSpec with Matchers
+  with ParallelTestExecution with MockFactory
+{
+  private val TestUniqueId = 1234L
+  private val mockObjectInfoProfile = mock[ObjectInfoProfile]
+
+  private val testObjectCache = new ObjectCache()
+  private val testScalaVirtualMachine = new Object with ScalaVirtualMachine {
+    override val cache: ObjectCache = testObjectCache
+    override val lowlevel: ManagerContainer = null
+    override def initialize(startProcessingEvents: Boolean): Unit = {}
+    override val underlyingVirtualMachine: VirtualMachine = null
+    override def isStarted: Boolean = false
+    override val uniqueId: String = ""
+    override protected val profileManager: ProfileManager = null
+    override def register(
+      name: String,
+      profile: DebugProfile
+    ): Option[DebugProfile] = None
+    override def retrieve(name: String): Option[DebugProfile] = None
+    override def unregister(name: String): Option[DebugProfile] = None
+  }
+
+  describe("ObjectInfoDSLWrapper") {
+    describe("#cache") {
+      it("should add the object to the implicit cache if available") {
+        import org.scaladebugger.api.dsl.Implicits.ObjectInfoDSL
+
+        (mockObjectInfoProfile.uniqueId _).expects()
+          .returning(TestUniqueId).once()
+
+        implicit val objectCache: ObjectCache = testObjectCache
+        mockObjectInfoProfile.cache()
+
+        objectCache.has(TestUniqueId) should be (true)
+      }
+
+      it("should add the object to underlying JVM's cache if no implicit available") {
+        import org.scaladebugger.api.dsl.Implicits.ObjectInfoDSL
+
+        (mockObjectInfoProfile.scalaVirtualMachine _).expects()
+          .returning(testScalaVirtualMachine).once()
+
+        (mockObjectInfoProfile.uniqueId _).expects()
+          .returning(TestUniqueId).once()
+
+        mockObjectInfoProfile.cache()
+
+        testObjectCache.has(TestUniqueId) should be (true)
+      }
+    }
+
+    describe("#uncache") {
+      it("should remove the object to the implicit cache if available") {
+        import org.scaladebugger.api.dsl.Implicits.ObjectInfoDSL
+
+        (mockObjectInfoProfile.uniqueId _).expects()
+          .returning(TestUniqueId).twice()
+
+        implicit val objectCache: ObjectCache = testObjectCache
+        objectCache.save(mockObjectInfoProfile)
+
+        mockObjectInfoProfile.uncache()
+
+        objectCache.has(TestUniqueId) should be (false)
+      }
+
+      it("should remove the object to underlying JVM's cache if no implicit available") {
+        import org.scaladebugger.api.dsl.Implicits.ObjectInfoDSL
+
+        (mockObjectInfoProfile.scalaVirtualMachine _).expects()
+          .returning(testScalaVirtualMachine).once()
+
+        (mockObjectInfoProfile.uniqueId _).expects()
+          .returning(TestUniqueId).twice()
+
+        testObjectCache.save(mockObjectInfoProfile)
+        mockObjectInfoProfile.uncache()
+
+        testObjectCache.has(TestUniqueId) should be (false)
+      }
+    }
+  }
+}

--- a/scala-debugger-api/src/test/scala/org/scaladebugger/api/profiles/pure/info/PureArrayInfoProfileSpec.scala
+++ b/scala-debugger-api/src/test/scala/org/scaladebugger/api/profiles/pure/info/PureArrayInfoProfileSpec.scala
@@ -4,18 +4,20 @@ import java.util
 
 import com.sun.jdi._
 import org.scaladebugger.api.profiles.traits.info.ValueInfoProfile
+import org.scaladebugger.api.virtualmachines.ScalaVirtualMachine
 import org.scalamock.scalatest.MockFactory
 import org.scalatest.{FunSpec, Matchers, ParallelTestExecution}
 
 class PureArrayInfoProfileSpec extends FunSpec with Matchers
   with ParallelTestExecution with MockFactory
 {
+  private val mockScalaVirtualMachine = mock[ScalaVirtualMachine]
   private val mockVirtualMachine = mock[VirtualMachine]
   private val mockThreadReference = mock[ThreadReference]
   private val mockReferenceType = mock[ReferenceType]
   private val mockArrayReference = mock[ArrayReference]
   private val pureArrayInfoProfile = new PureArrayInfoProfile(
-    mockArrayReference
+    mockScalaVirtualMachine, mockArrayReference
   )(
     virtualMachine = mockVirtualMachine,
     threadReference = mockThreadReference,
@@ -51,7 +53,7 @@ class PureArrayInfoProfileSpec extends FunSpec with Matchers
         val mockValue = mock[Value]
 
         val pureArrayInfoProfile = new PureArrayInfoProfile(
-          mockArrayReference
+          mockScalaVirtualMachine, mockArrayReference
         )(
           virtualMachine = mockVirtualMachine,
           threadReference = mockThreadReference,
@@ -76,7 +78,7 @@ class PureArrayInfoProfileSpec extends FunSpec with Matchers
         val mockValues = Seq(mock[Value])
 
         val pureArrayInfoProfile = new PureArrayInfoProfile(
-          mockArrayReference
+          mockScalaVirtualMachine, mockArrayReference
         )(
           virtualMachine = mockVirtualMachine,
           threadReference = mockThreadReference,
@@ -103,7 +105,7 @@ class PureArrayInfoProfileSpec extends FunSpec with Matchers
         val mockValues = Seq(mock[Value])
 
         val pureArrayInfoProfile = new PureArrayInfoProfile(
-          mockArrayReference
+          mockScalaVirtualMachine, mockArrayReference
         )(
           virtualMachine = mockVirtualMachine,
           threadReference = mockThreadReference,
@@ -169,7 +171,7 @@ class PureArrayInfoProfileSpec extends FunSpec with Matchers
         import scala.collection.JavaConverters._
         mockSetValues.expects(index, mockValues.asJava, srcIndex, totalElements).once()
         val pureArrayInfoProfile = new PureArrayInfoProfile(
-          testArrayReference
+          mockScalaVirtualMachine, testArrayReference
         )(
           virtualMachine = mockVirtualMachine,
           threadReference = mockThreadReference,
@@ -210,7 +212,7 @@ class PureArrayInfoProfileSpec extends FunSpec with Matchers
         import scala.collection.JavaConverters._
         mockSetValues.expects(mockValues.asJava).once()
         val pureArrayInfoProfile = new PureArrayInfoProfile(
-          testArrayReference
+          mockScalaVirtualMachine, testArrayReference
         )(
           virtualMachine = mockVirtualMachine,
           threadReference = mockThreadReference,

--- a/scala-debugger-api/src/test/scala/org/scaladebugger/api/profiles/pure/info/PureClassLoaderInfoProfileSpec.scala
+++ b/scala-debugger-api/src/test/scala/org/scaladebugger/api/profiles/pure/info/PureClassLoaderInfoProfileSpec.scala
@@ -2,6 +2,7 @@ package org.scaladebugger.api.profiles.pure.info
 
 import com.sun.jdi._
 import org.scaladebugger.api.profiles.traits.info._
+import org.scaladebugger.api.virtualmachines.ScalaVirtualMachine
 import org.scalamock.scalatest.MockFactory
 import org.scalatest.{FunSpec, Matchers, ParallelTestExecution}
 
@@ -9,12 +10,13 @@ class PureClassLoaderInfoProfileSpec extends FunSpec with Matchers
   with ParallelTestExecution with MockFactory
 {
   private val mockNewReferenceTypeProfile = mockFunction[ReferenceType, ReferenceTypeInfoProfile]
+  private val mockScalaVirtualMachine = mock[ScalaVirtualMachine]
   private val mockVirtualMachine = mock[VirtualMachine]
   private val mockReferenceType = mock[ReferenceType]
   private val mockThreadReference = mock[ThreadReference]
   private val mockClassLoaderReference = mock[ClassLoaderReference]
   private val pureClassLoaderInfoProfile = new PureClassLoaderInfoProfile(
-    mockClassLoaderReference
+    mockScalaVirtualMachine, mockClassLoaderReference
   )(
     threadReference = mockThreadReference,
     virtualMachine = mockVirtualMachine,

--- a/scala-debugger-api/src/test/scala/org/scaladebugger/api/profiles/pure/info/PureClassObjectInfoProfileSpec.scala
+++ b/scala-debugger-api/src/test/scala/org/scaladebugger/api/profiles/pure/info/PureClassObjectInfoProfileSpec.scala
@@ -3,6 +3,7 @@ package org.scaladebugger.api.profiles.pure.info
 import com.sun.jdi._
 import org.scaladebugger.api.lowlevel.{InvokeNonVirtualArgument, InvokeSingleThreadedArgument, JDIArgument}
 import org.scaladebugger.api.profiles.traits.info._
+import org.scaladebugger.api.virtualmachines.ScalaVirtualMachine
 import org.scalamock.scalatest.MockFactory
 import org.scalatest.{FunSpec, Matchers, ParallelTestExecution}
 
@@ -10,12 +11,13 @@ class PureClassObjectInfoProfileSpec extends FunSpec with Matchers
   with ParallelTestExecution with MockFactory
 {
   private val mockNewReferenceTypeProfile = mockFunction[ReferenceType, ReferenceTypeInfoProfile]
+  private val mockScalaVirtualMachine = mock[ScalaVirtualMachine]
   private val mockVirtualMachine = mock[VirtualMachine]
   private val mockReferenceType = mock[ReferenceType]
   private val mockThreadReference = mock[ThreadReference]
   private val mockClassObjectReference = mock[ClassObjectReference]
   private val pureClassObjectInfoProfile = new PureClassObjectInfoProfile(
-    mockClassObjectReference
+    mockScalaVirtualMachine, mockClassObjectReference
   )(
     threadReference = mockThreadReference,
     virtualMachine = mockVirtualMachine,

--- a/scala-debugger-api/src/test/scala/org/scaladebugger/api/profiles/pure/info/PureFieldInfoProfileSpec.scala
+++ b/scala-debugger-api/src/test/scala/org/scaladebugger/api/profiles/pure/info/PureFieldInfoProfileSpec.scala
@@ -2,16 +2,19 @@ package org.scaladebugger.api.profiles.pure.info
 
 import com.sun.jdi._
 import org.scaladebugger.api.profiles.traits.info.ValueInfoProfile
+import org.scaladebugger.api.virtualmachines.ScalaVirtualMachine
 import org.scalamock.scalatest.MockFactory
 import org.scalatest.{FunSpec, Matchers, ParallelTestExecution}
 
 class PureFieldInfoProfileSpec extends FunSpec with Matchers
   with ParallelTestExecution with MockFactory
 {
+  private val mockScalaVirtualMachine = mock[ScalaVirtualMachine]
   private val mockVirtualMachine = mock[VirtualMachine]
   private val mockObjectReference = mock[ObjectReference]
   private val mockField = mock[Field]
   private val pureFieldInfoProfile = new PureFieldInfoProfile(
+    mockScalaVirtualMachine,
     mockObjectReference,
     mockField
   )(mockVirtualMachine)
@@ -72,6 +75,7 @@ class PureFieldInfoProfileSpec extends FunSpec with Matchers
     describe("#setValue") {
       it("should throw an exception if no object reference available") {
         val pureFieldInfoProfile = new PureFieldInfoProfile(
+          mockScalaVirtualMachine,
           null,
           mockField
         )(mockVirtualMachine)
@@ -122,6 +126,7 @@ class PureFieldInfoProfileSpec extends FunSpec with Matchers
     describe("#toValue") {
       it("should throw an exception if no object reference available") {
         val pureFieldInfoProfile = new PureFieldInfoProfile(
+          mockScalaVirtualMachine,
           null,
           mockField
         )(mockVirtualMachine)
@@ -141,6 +146,7 @@ class PureFieldInfoProfileSpec extends FunSpec with Matchers
 
         val mockNewValueProfile = mockFunction[Value, ValueInfoProfile]
         val pureFieldInfoProfile = new PureFieldInfoProfile(
+          mockScalaVirtualMachine,
           mockObjectReference,
           mockField
         )(mockVirtualMachine) {

--- a/scala-debugger-api/src/test/scala/org/scaladebugger/api/profiles/pure/info/PureFrameInfoProfileSpec.scala
+++ b/scala-debugger-api/src/test/scala/org/scaladebugger/api/profiles/pure/info/PureFrameInfoProfileSpec.scala
@@ -2,6 +2,7 @@ package org.scaladebugger.api.profiles.pure.info
 
 import com.sun.jdi._
 import org.scaladebugger.api.profiles.traits.info._
+import org.scaladebugger.api.virtualmachines.ScalaVirtualMachine
 import org.scalamock.scalatest.MockFactory
 import org.scalatest.{FunSpec, Matchers, ParallelTestExecution}
 
@@ -15,8 +16,13 @@ class PureFrameInfoProfileSpec extends FunSpec with Matchers
   private val mockNewValueProfile = mockFunction[Value, ValueInfoProfile]
 
   private val TestFrameIndex = 999
+  private val mockScalaVirtualMachine = mock[ScalaVirtualMachine]
   private val mockStackFrame = mock[StackFrame]
-  private val pureFrameInfoProfile = new PureFrameInfoProfile(mockStackFrame, TestFrameIndex) {
+  private val pureFrameInfoProfile = new PureFrameInfoProfile(
+    mockScalaVirtualMachine,
+    mockStackFrame,
+    TestFrameIndex
+  ) {
     override protected def newLocalVariableProfile(
       localVariable: LocalVariable, offsetIndex: Int
     ): IndexedVariableInfoProfile = mockNewLocalVariableProfile(
@@ -252,7 +258,11 @@ class PureFrameInfoProfileSpec extends FunSpec with Matchers
         val localVariables = Seq(mock[IndexedVariableInfoProfile])
         val expected = localVariables ++ fieldVariables
 
-        val pureFrameInfoProfile = new PureFrameInfoProfile(mockStackFrame, 0) {
+        val pureFrameInfoProfile = new PureFrameInfoProfile(
+          mockScalaVirtualMachine,
+          mockStackFrame,
+          0
+        ) {
           override def getFieldVariables: Seq[VariableInfoProfile] =
             fieldVariables
           override def getLocalVariables: Seq[IndexedVariableInfoProfile] =
@@ -310,7 +320,11 @@ class PureFrameInfoProfileSpec extends FunSpec with Matchers
         val expected = Seq(mock[IndexedVariableInfoProfile])
         val other = Seq(mock[IndexedVariableInfoProfile])
 
-        val pureFrameInfoProfile = new PureFrameInfoProfile(mockStackFrame, TestFrameIndex) {
+        val pureFrameInfoProfile = new PureFrameInfoProfile(
+          mockScalaVirtualMachine,
+          mockStackFrame,
+          TestFrameIndex
+        ) {
           override def getLocalVariables: Seq[IndexedVariableInfoProfile] =
             expected ++ other
         }
@@ -329,7 +343,11 @@ class PureFrameInfoProfileSpec extends FunSpec with Matchers
         val expected = Seq(mock[IndexedVariableInfoProfile])
         val other = Seq(mock[IndexedVariableInfoProfile])
 
-        val pureFrameInfoProfile = new PureFrameInfoProfile(mockStackFrame, TestFrameIndex) {
+        val pureFrameInfoProfile = new PureFrameInfoProfile(
+          mockScalaVirtualMachine,
+          mockStackFrame,
+          TestFrameIndex
+        ) {
           override def getLocalVariables: Seq[IndexedVariableInfoProfile] =
             expected ++ other
         }

--- a/scala-debugger-api/src/test/scala/org/scaladebugger/api/profiles/pure/info/PureGrabInfoProfileSpec.scala
+++ b/scala-debugger-api/src/test/scala/org/scaladebugger/api/profiles/pure/info/PureGrabInfoProfileSpec.scala
@@ -3,6 +3,7 @@ package org.scaladebugger.api.profiles.pure.info
 import com.sun.jdi.{ReferenceType, ThreadReference, VirtualMachine}
 import org.scaladebugger.api.lowlevel.wrappers.ReferenceTypeWrapper
 import org.scaladebugger.api.profiles.traits.info.ReferenceTypeInfoProfile
+import org.scaladebugger.api.virtualmachines.ScalaVirtualMachine
 import org.scalamock.scalatest.MockFactory
 import org.scalatest.{FunSpec, Matchers, ParallelTestExecution}
 
@@ -10,8 +11,10 @@ class PureGrabInfoProfileSpec extends FunSpec with Matchers
   with ParallelTestExecution with MockFactory
 {
   private val mockNewReferenceTypeProfile = mockFunction[ReferenceType, ReferenceTypeInfoProfile]
+  private val mockScalaVirtualMachine = mock[ScalaVirtualMachine]
   private val mockVirtualMachine = mock[VirtualMachine]
   private val pureGrabInfoProfile = new PureGrabInfoProfile {
+    override protected val scalaVirtualMachine: ScalaVirtualMachine = mockScalaVirtualMachine
     override protected val _virtualMachine: VirtualMachine = mockVirtualMachine
 
     override protected def newReferenceTypeProfile(

--- a/scala-debugger-api/src/test/scala/org/scaladebugger/api/profiles/pure/info/PureLocalVariableInfoProfileSpec.scala
+++ b/scala-debugger-api/src/test/scala/org/scaladebugger/api/profiles/pure/info/PureLocalVariableInfoProfileSpec.scala
@@ -2,17 +2,20 @@ package org.scaladebugger.api.profiles.pure.info
 
 import com.sun.jdi._
 import org.scaladebugger.api.profiles.traits.info.{FrameInfoProfile, ValueInfoProfile}
+import org.scaladebugger.api.virtualmachines.ScalaVirtualMachine
 import org.scalamock.scalatest.MockFactory
 import org.scalatest.{FunSpec, Matchers, ParallelTestExecution}
 
 class PureLocalVariableInfoProfileSpec extends FunSpec with Matchers
   with ParallelTestExecution with MockFactory
 {
+  private val mockScalaVirtualMachine = mock[ScalaVirtualMachine]
   private val mockVirtualMachine = mock[VirtualMachine]
   private val mockFrameInfoProfile = mock[FrameInfoProfile]
   private val mockLocalVariable = mock[LocalVariable]
   private val TestOffsetIndex = 999
   private val pureLocalVariableInfoProfile = new PureLocalVariableInfoProfile(
+    mockScalaVirtualMachine,
     mockFrameInfoProfile,
     mockLocalVariable,
     TestOffsetIndex
@@ -143,6 +146,7 @@ class PureLocalVariableInfoProfileSpec extends FunSpec with Matchers
 
         val mockNewValueProfile = mockFunction[Value, ValueInfoProfile]
         val pureLocalVariableInfoProfile = new PureLocalVariableInfoProfile(
+          mockScalaVirtualMachine,
           mockFrameInfoProfile,
           mockLocalVariable,
           TestOffsetIndex

--- a/scala-debugger-api/src/test/scala/org/scaladebugger/api/profiles/pure/info/PureLocationInfoProfileSpec.scala
+++ b/scala-debugger-api/src/test/scala/org/scaladebugger/api/profiles/pure/info/PureLocationInfoProfileSpec.scala
@@ -2,6 +2,7 @@ package org.scaladebugger.api.profiles.pure.info
 
 import com.sun.jdi._
 import org.scaladebugger.api.profiles.traits.info.{MethodInfoProfile, ReferenceTypeInfoProfile}
+import org.scaladebugger.api.virtualmachines.ScalaVirtualMachine
 import org.scalamock.scalatest.MockFactory
 import org.scalatest.{FunSpec, Matchers, ParallelTestExecution}
 
@@ -10,8 +11,10 @@ class PureLocationInfoProfileSpec extends FunSpec with Matchers
 {
   private val mockNewMethodProfile = mockFunction[Method, MethodInfoProfile]
   private val mockNewReferenceTypeProfile = mockFunction[ReferenceType, ReferenceTypeInfoProfile]
+  private val mockScalaVirtualMachine = mock[ScalaVirtualMachine]
   private val mockLocation = mock[Location]
   private val pureLocationInfoProfile = new PureLocationInfoProfile(
+    scalaVirtualMachine = mockScalaVirtualMachine,
     location = mockLocation
   ) {
     override protected def newReferenceTypeProfile(

--- a/scala-debugger-api/src/test/scala/org/scaladebugger/api/profiles/pure/info/PureMethodInfoProfileSpec.scala
+++ b/scala-debugger-api/src/test/scala/org/scaladebugger/api/profiles/pure/info/PureMethodInfoProfileSpec.scala
@@ -1,14 +1,19 @@
 package org.scaladebugger.api.profiles.pure.info
 
 import com.sun.jdi.Method
+import org.scaladebugger.api.virtualmachines.ScalaVirtualMachine
 import org.scalamock.scalatest.MockFactory
 import org.scalatest.{FunSpec, Matchers, ParallelTestExecution}
 
 class PureMethodInfoProfileSpec extends FunSpec with Matchers
   with ParallelTestExecution with MockFactory
 {
+  private val mockScalaVirtualMachine = mock[ScalaVirtualMachine]
   private val mockMethod = mock[Method]
-  private val pureMethodInfoProfile = new PureMethodInfoProfile(mockMethod)
+  private val pureMethodInfoProfile = new PureMethodInfoProfile(
+    mockScalaVirtualMachine,
+    mockMethod
+  )
 
   describe("PureMethodInfoProfile") {
     describe("#toJdiInstance") {

--- a/scala-debugger-api/src/test/scala/org/scaladebugger/api/profiles/pure/info/PureMiscInfoProfileSpec.scala
+++ b/scala-debugger-api/src/test/scala/org/scaladebugger/api/profiles/pure/info/PureMiscInfoProfileSpec.scala
@@ -5,6 +5,7 @@ import org.scalamock.scalatest.MockFactory
 import org.scalatest.{FunSpec, Matchers, ParallelTestExecution}
 import org.scaladebugger.api.lowlevel.classes.ClassManager
 import org.scaladebugger.api.profiles.traits.info.ReferenceTypeInfoProfile
+import org.scaladebugger.api.virtualmachines.ScalaVirtualMachine
 import test.JDIMockHelpers
 
 import scala.util.{Failure, Success}
@@ -12,6 +13,7 @@ import scala.util.{Failure, Success}
 class PureMiscInfoProfileSpec extends FunSpec with Matchers
   with ParallelTestExecution with MockFactory with JDIMockHelpers
 {
+  private val mockScalaVirtualMachine = mock[ScalaVirtualMachine]
   private val mockVirtualMachine = mock[VirtualMachine]
   private val mockClassManager = mock[ClassManager]
 
@@ -29,6 +31,7 @@ class PureMiscInfoProfileSpec extends FunSpec with Matchers
     ): ReferenceTypeInfoProfile = mockMiscNewReferenceTypeProfile(referenceType)
 
     override protected val classManager: ClassManager = mockClassManager
+    override protected val scalaVirtualMachine: ScalaVirtualMachine = mockScalaVirtualMachine
     override protected val _virtualMachine: VirtualMachine = mockVirtualMachine
   }
 

--- a/scala-debugger-api/src/test/scala/org/scaladebugger/api/profiles/pure/info/PureObjectInfoProfileSpec.scala
+++ b/scala-debugger-api/src/test/scala/org/scaladebugger/api/profiles/pure/info/PureObjectInfoProfileSpec.scala
@@ -3,6 +3,7 @@ package org.scaladebugger.api.profiles.pure.info
 import com.sun.jdi._
 import org.scaladebugger.api.lowlevel.{InvokeNonVirtualArgument, InvokeSingleThreadedArgument, JDIArgument}
 import org.scaladebugger.api.profiles.traits.info._
+import org.scaladebugger.api.virtualmachines.ScalaVirtualMachine
 import org.scalamock.scalatest.MockFactory
 import org.scalatest.{FunSpec, Matchers, ParallelTestExecution}
 
@@ -14,11 +15,13 @@ class PureObjectInfoProfileSpec extends FunSpec with Matchers
   private val mockNewValueProfile = mockFunction[Value, ValueInfoProfile]
   private val mockNewTypeCheckerProfile = mockFunction[TypeCheckerProfile]
   private val mockNewReferenceTypeProfile = mockFunction[ReferenceType, ReferenceTypeInfoProfile]
+  private val mockScalaVirtualMachine = mock[ScalaVirtualMachine]
   private val mockVirtualMachine = mock[VirtualMachine]
   private val mockReferenceType = mock[ReferenceType]
   private val mockThreadReference = mock[ThreadReference]
   private val mockObjectReference = mock[ObjectReference]
   private val pureObjectInfoProfile = new PureObjectInfoProfile(
+    mockScalaVirtualMachine,
     mockObjectReference
   )(
     threadReference = mockThreadReference,
@@ -102,6 +105,7 @@ class PureObjectInfoProfileSpec extends FunSpec with Matchers
         val mockUnsafeMethod = mockFunction[String, Seq[String], MethodInfoProfile]
 
         val pureObjectInfoProfile = new PureObjectInfoProfile(
+          mockScalaVirtualMachine,
           mockObjectReference
         )(
           threadReference = mockThreadReference,
@@ -146,7 +150,10 @@ class PureObjectInfoProfileSpec extends FunSpec with Matchers
         val expected = mock[ValueInfoProfile]
 
         val mockMethod = mock[Method]
-        val pureMethodInfoProfile = new PureMethodInfoProfile(mockMethod)
+        val pureMethodInfoProfile = new PureMethodInfoProfile(
+          mockScalaVirtualMachine,
+          mockMethod
+        )
 
         // Object method is invoked
         val mockValue = mock[Value]
@@ -173,7 +180,10 @@ class PureObjectInfoProfileSpec extends FunSpec with Matchers
         val arguments = Seq(1)
 
         val mockMethod = mock[Method]
-        val pureMethodInfoProfile = new PureMethodInfoProfile(mockMethod)
+        val pureMethodInfoProfile = new PureMethodInfoProfile(
+          mockScalaVirtualMachine,
+          mockMethod
+        )
 
         // Arguments are mirrored remotely
         val mockValues = Seq(mock[IntegerValue])
@@ -208,7 +218,10 @@ class PureObjectInfoProfileSpec extends FunSpec with Matchers
         )
 
         val mockMethod = mock[Method]
-        val pureMethodInfoProfile = new PureMethodInfoProfile(mockMethod)
+        val pureMethodInfoProfile = new PureMethodInfoProfile(
+          mockScalaVirtualMachine,
+          mockMethod
+        )
 
         // Object method is invoked
         // NOTE: Both arguments OR'd together is 3 (1 | 2)

--- a/scala-debugger-api/src/test/scala/org/scaladebugger/api/profiles/pure/info/PurePrimitiveInfoProfileSpec.scala
+++ b/scala-debugger-api/src/test/scala/org/scaladebugger/api/profiles/pure/info/PurePrimitiveInfoProfileSpec.scala
@@ -2,12 +2,14 @@ package org.scaladebugger.api.profiles.pure.info
 
 import com.sun.jdi._
 import org.scaladebugger.api.profiles.traits.info.{ArrayInfoProfile, ObjectInfoProfile, PrimitiveInfoProfile}
+import org.scaladebugger.api.virtualmachines.ScalaVirtualMachine
 import org.scalamock.scalatest.MockFactory
 import org.scalatest.{FunSpec, Matchers, ParallelTestExecution}
 
 class PurePrimitiveInfoProfileSpec extends FunSpec with Matchers
   with ParallelTestExecution with MockFactory
 {
+  private val mockScalaVirtualMachine = mock[ScalaVirtualMachine]
   private val mockPrimitiveValue = mock[PrimitiveValue]
 
   describe("PurePrimitiveInfoProfile") {
@@ -16,6 +18,7 @@ class PurePrimitiveInfoProfileSpec extends FunSpec with Matchers
         val expected = mockPrimitiveValue
 
         val purePrimitiveInfoProfile = new PurePrimitiveInfoProfile(
+          mockScalaVirtualMachine,
           mockPrimitiveValue
         )
 
@@ -30,6 +33,7 @@ class PurePrimitiveInfoProfileSpec extends FunSpec with Matchers
         val expected = true
 
         val purePrimitiveInfoProfile = new PurePrimitiveInfoProfile(
+          mockScalaVirtualMachine,
           mock[BooleanValue]
         )
 
@@ -42,6 +46,7 @@ class PurePrimitiveInfoProfileSpec extends FunSpec with Matchers
         val expected = false
 
         val purePrimitiveInfoProfile = new PurePrimitiveInfoProfile(
+          mockScalaVirtualMachine,
           mock[PrimitiveValue]
         )
 
@@ -56,6 +61,7 @@ class PurePrimitiveInfoProfileSpec extends FunSpec with Matchers
         val expected = true
 
         val purePrimitiveInfoProfile = new PurePrimitiveInfoProfile(
+          mockScalaVirtualMachine,
           mock[ByteValue]
         )
 
@@ -68,6 +74,7 @@ class PurePrimitiveInfoProfileSpec extends FunSpec with Matchers
         val expected = false
 
         val purePrimitiveInfoProfile = new PurePrimitiveInfoProfile(
+          mockScalaVirtualMachine,
           mock[PrimitiveValue]
         )
 
@@ -82,6 +89,7 @@ class PurePrimitiveInfoProfileSpec extends FunSpec with Matchers
         val expected = true
 
         val purePrimitiveInfoProfile = new PurePrimitiveInfoProfile(
+          mockScalaVirtualMachine,
           mock[CharValue]
         )
 
@@ -94,6 +102,7 @@ class PurePrimitiveInfoProfileSpec extends FunSpec with Matchers
         val expected = false
 
         val purePrimitiveInfoProfile = new PurePrimitiveInfoProfile(
+          mockScalaVirtualMachine,
           mock[PrimitiveValue]
         )
 
@@ -108,6 +117,7 @@ class PurePrimitiveInfoProfileSpec extends FunSpec with Matchers
         val expected = true
 
         val purePrimitiveInfoProfile = new PurePrimitiveInfoProfile(
+          mockScalaVirtualMachine,
           mock[IntegerValue]
         )
 
@@ -120,6 +130,7 @@ class PurePrimitiveInfoProfileSpec extends FunSpec with Matchers
         val expected = false
 
         val purePrimitiveInfoProfile = new PurePrimitiveInfoProfile(
+          mockScalaVirtualMachine,
           mock[PrimitiveValue]
         )
 
@@ -134,6 +145,7 @@ class PurePrimitiveInfoProfileSpec extends FunSpec with Matchers
         val expected = true
 
         val purePrimitiveInfoProfile = new PurePrimitiveInfoProfile(
+          mockScalaVirtualMachine,
           mock[LongValue]
         )
 
@@ -146,6 +158,7 @@ class PurePrimitiveInfoProfileSpec extends FunSpec with Matchers
         val expected = false
 
         val purePrimitiveInfoProfile = new PurePrimitiveInfoProfile(
+          mockScalaVirtualMachine,
           mock[PrimitiveValue]
         )
 
@@ -160,6 +173,7 @@ class PurePrimitiveInfoProfileSpec extends FunSpec with Matchers
         val expected = true
 
         val purePrimitiveInfoProfile = new PurePrimitiveInfoProfile(
+          mockScalaVirtualMachine,
           mock[ShortValue]
         )
 
@@ -172,6 +186,7 @@ class PurePrimitiveInfoProfileSpec extends FunSpec with Matchers
         val expected = false
 
         val purePrimitiveInfoProfile = new PurePrimitiveInfoProfile(
+          mockScalaVirtualMachine,
           mock[PrimitiveValue]
         )
 
@@ -186,6 +201,7 @@ class PurePrimitiveInfoProfileSpec extends FunSpec with Matchers
         val expected = true
 
         val purePrimitiveInfoProfile = new PurePrimitiveInfoProfile(
+          mockScalaVirtualMachine,
           mock[DoubleValue]
         )
 
@@ -198,6 +214,7 @@ class PurePrimitiveInfoProfileSpec extends FunSpec with Matchers
         val expected = false
 
         val purePrimitiveInfoProfile = new PurePrimitiveInfoProfile(
+          mockScalaVirtualMachine,
           mock[PrimitiveValue]
         )
 
@@ -212,6 +229,7 @@ class PurePrimitiveInfoProfileSpec extends FunSpec with Matchers
         val expected = true
 
         val purePrimitiveInfoProfile = new PurePrimitiveInfoProfile(
+          mockScalaVirtualMachine,
           mock[FloatValue]
         )
 
@@ -224,6 +242,7 @@ class PurePrimitiveInfoProfileSpec extends FunSpec with Matchers
         val expected = false
 
         val purePrimitiveInfoProfile = new PurePrimitiveInfoProfile(
+          mockScalaVirtualMachine,
           mock[PrimitiveValue]
         )
 

--- a/scala-debugger-api/src/test/scala/org/scaladebugger/api/profiles/pure/info/PureReferenceTypeInfoProfileSpec.scala
+++ b/scala-debugger-api/src/test/scala/org/scaladebugger/api/profiles/pure/info/PureReferenceTypeInfoProfileSpec.scala
@@ -2,6 +2,7 @@ package org.scaladebugger.api.profiles.pure.info
 
 import com.sun.jdi._
 import org.scaladebugger.api.profiles.traits.info._
+import org.scaladebugger.api.virtualmachines.ScalaVirtualMachine
 import org.scalamock.scalatest.MockFactory
 import org.scalatest.{FunSpec, Matchers, ParallelTestExecution}
 
@@ -15,8 +16,10 @@ class PureReferenceTypeInfoProfileSpec extends FunSpec with Matchers
   private val mockNewClassLoaderProfile = mockFunction[ClassLoaderReference, ClassLoaderInfoProfile]
   private val mockNewClassObjectProfile = mockFunction[ClassObjectReference, ClassObjectInfoProfile]
   private val mockNewReferenceTypeProfile = mockFunction[ReferenceType, ReferenceTypeInfoProfile]
+  private val mockScalaVirtualMachine = mock[ScalaVirtualMachine]
   private val mockReferenceType = mock[ReferenceType]
   private val pureReferenceTypeInfoProfile = new PureReferenceTypeInfoProfile(
+    scalaVirtualMachine = mockScalaVirtualMachine,
     referenceType = mockReferenceType
   ) {
     override protected def newFieldProfile(

--- a/scala-debugger-api/src/test/scala/org/scaladebugger/api/profiles/pure/info/PureThreadInfoProfileSpec.scala
+++ b/scala-debugger-api/src/test/scala/org/scaladebugger/api/profiles/pure/info/PureThreadInfoProfileSpec.scala
@@ -1,18 +1,21 @@
 package org.scaladebugger.api.profiles.pure.info
 
-import com.sun.jdi.{ReferenceType, VirtualMachine, StackFrame, ThreadReference}
+import com.sun.jdi.{ReferenceType, StackFrame, ThreadReference, VirtualMachine}
 import org.scaladebugger.api.profiles.traits.info.FrameInfoProfile
+import org.scaladebugger.api.virtualmachines.ScalaVirtualMachine
 import org.scalamock.scalatest.MockFactory
 import org.scalatest.{FunSpec, Matchers, ParallelTestExecution}
 
 class PureThreadInfoProfileSpec extends FunSpec with Matchers
   with ParallelTestExecution with MockFactory
 {
+  private val mockScalaVirtualMachine = mock[ScalaVirtualMachine]
   private val mockVirtualMachine = mock[VirtualMachine]
   private val mockReferenceType = mock[ReferenceType]
   private val mockNewFrameProfile = mockFunction[StackFrame, Int, FrameInfoProfile]
   private val mockThreadReference = mock[ThreadReference]
   private val pureThreadInfoProfile = new PureThreadInfoProfile(
+    mockScalaVirtualMachine,
     mockThreadReference
   )(
     virtualMachine = mockVirtualMachine,

--- a/scala-debugger-api/src/test/scala/org/scaladebugger/api/profiles/pure/info/PureValueInfoProfileSpec.scala
+++ b/scala-debugger-api/src/test/scala/org/scaladebugger/api/profiles/pure/info/PureValueInfoProfileSpec.scala
@@ -2,12 +2,14 @@ package org.scaladebugger.api.profiles.pure.info
 
 import com.sun.jdi._
 import org.scaladebugger.api.profiles.traits.info.{ArrayInfoProfile, ObjectInfoProfile, PrimitiveInfoProfile, ValueInfoProfile}
+import org.scaladebugger.api.virtualmachines.ScalaVirtualMachine
 import org.scalamock.scalatest.MockFactory
 import org.scalatest.{FunSpec, Matchers, ParallelTestExecution}
 
 class PureValueInfoProfileSpec extends FunSpec with Matchers
   with ParallelTestExecution with MockFactory
 {
+  private val mockScalaVirtualMachine = mock[ScalaVirtualMachine]
   private val mockValue = mock[Value]
   private val mockNewPrimitiveProfile = mockFunction[PrimitiveValue, PrimitiveInfoProfile]
   private val mockNewObjectProfile = mockFunction[ObjectReference, ObjectInfoProfile]
@@ -18,7 +20,10 @@ class PureValueInfoProfileSpec extends FunSpec with Matchers
       it("should return the JDI instance this profile instance represents") {
         val expected = mockValue
 
-        val pureValueInfoProfile = new PureValueInfoProfile(mockValue)
+        val pureValueInfoProfile = new PureValueInfoProfile(
+          mockScalaVirtualMachine,
+          mockValue
+        )
 
         val actual = pureValueInfoProfile.toJdiInstance
 
@@ -37,6 +42,7 @@ class PureValueInfoProfileSpec extends FunSpec with Matchers
         (mockValue.`type` _).expects().returning(mockType).once()
 
         val pureValueInfoProfile = new PureValueInfoProfile(
+          mockScalaVirtualMachine,
           mockValue
         )
         val actual = pureValueInfoProfile.typeName
@@ -48,6 +54,7 @@ class PureValueInfoProfileSpec extends FunSpec with Matchers
         val expected = PureValueInfoProfile.DefaultNullTypeName
 
         val pureValueInfoProfile = new PureValueInfoProfile(
+          mockScalaVirtualMachine,
           null
         )
 
@@ -60,6 +67,7 @@ class PureValueInfoProfileSpec extends FunSpec with Matchers
     describe("#toArray") {
       it("should throw an assertion error if the value is null") {
         val pureValueInfoProfile = new PureValueInfoProfile(
+          mockScalaVirtualMachine,
           null
         )
 
@@ -70,6 +78,7 @@ class PureValueInfoProfileSpec extends FunSpec with Matchers
 
       it("should throw an assertion error if the value is not an array") {
         val pureValueInfoProfile = new PureValueInfoProfile(
+          mockScalaVirtualMachine,
           mock[Value]
         )
 
@@ -83,6 +92,7 @@ class PureValueInfoProfileSpec extends FunSpec with Matchers
         val mockArrayReference = mock[ArrayReference]
 
         val pureValueInfoProfile = new PureValueInfoProfile(
+          mockScalaVirtualMachine,
           mockArrayReference
         ) {
           override protected def newArrayProfile(
@@ -102,6 +112,7 @@ class PureValueInfoProfileSpec extends FunSpec with Matchers
     describe("#toPrimitive") {
       it("should throw an assertion error if the value is null") {
         val pureValueInfoProfile = new PureValueInfoProfile(
+          mockScalaVirtualMachine,
           null
         )
 
@@ -112,6 +123,7 @@ class PureValueInfoProfileSpec extends FunSpec with Matchers
 
       it("should throw an assertion error if the value is not an primitive") {
         val pureValueInfoProfile = new PureValueInfoProfile(
+          mockScalaVirtualMachine,
           mock[Value]
         )
 
@@ -125,6 +137,7 @@ class PureValueInfoProfileSpec extends FunSpec with Matchers
         val mockPrimitiveValue = mock[PrimitiveValue]
 
         val pureValueInfoProfile = new PureValueInfoProfile(
+          mockScalaVirtualMachine,
           mockPrimitiveValue
         ) {
           override protected def newPrimitiveProfile(
@@ -144,6 +157,7 @@ class PureValueInfoProfileSpec extends FunSpec with Matchers
     describe("#toObject") {
       it("should throw an assertion error if the value is null") {
         val pureValueInfoProfile = new PureValueInfoProfile(
+          mockScalaVirtualMachine,
           null
         )
 
@@ -154,6 +168,7 @@ class PureValueInfoProfileSpec extends FunSpec with Matchers
 
       it("should throw an assertion error if the value is not an object") {
         val pureValueInfoProfile = new PureValueInfoProfile(
+          mockScalaVirtualMachine,
           mock[Value]
         )
 
@@ -167,6 +182,7 @@ class PureValueInfoProfileSpec extends FunSpec with Matchers
         val mockObjectReference = mock[ObjectReference]
 
         val pureValueInfoProfile = new PureValueInfoProfile(
+          mockScalaVirtualMachine,
           mockObjectReference
         ) {
           override protected def newObjectProfile(
@@ -188,6 +204,7 @@ class PureValueInfoProfileSpec extends FunSpec with Matchers
         val expected: Any = null
 
         val pureValueInfoProfile = new PureValueInfoProfile(
+          mockScalaVirtualMachine,
           null
         )
 
@@ -201,6 +218,7 @@ class PureValueInfoProfileSpec extends FunSpec with Matchers
         val mockStringReference = mock[StringReference]
 
         val pureValueInfoProfile = new PureValueInfoProfile(
+          mockScalaVirtualMachine,
           mockStringReference
         )
 
@@ -216,6 +234,7 @@ class PureValueInfoProfileSpec extends FunSpec with Matchers
         val expected = false
 
         val pureValueInfoProfile = new PureValueInfoProfile(
+          mockScalaVirtualMachine,
           null
         )
 
@@ -228,6 +247,7 @@ class PureValueInfoProfileSpec extends FunSpec with Matchers
         val expected = false
 
         val pureValueInfoProfile = new PureValueInfoProfile(
+          mockScalaVirtualMachine,
           mock[Value]
         )
 
@@ -240,6 +260,7 @@ class PureValueInfoProfileSpec extends FunSpec with Matchers
         val expected = true
 
         val pureValueInfoProfile = new PureValueInfoProfile(
+          mockScalaVirtualMachine,
           mock[PrimitiveValue]
         )
 
@@ -254,6 +275,7 @@ class PureValueInfoProfileSpec extends FunSpec with Matchers
         val expected = false
 
         val pureValueInfoProfile = new PureValueInfoProfile(
+          mockScalaVirtualMachine,
           null
         )
 
@@ -266,6 +288,7 @@ class PureValueInfoProfileSpec extends FunSpec with Matchers
         val expected = false
 
         val pureValueInfoProfile = new PureValueInfoProfile(
+          mockScalaVirtualMachine,
           mock[Value]
         )
 
@@ -278,6 +301,7 @@ class PureValueInfoProfileSpec extends FunSpec with Matchers
         val expected = true
 
         val pureValueInfoProfile = new PureValueInfoProfile(
+          mockScalaVirtualMachine,
           mock[VoidValue]
         )
 
@@ -292,6 +316,7 @@ class PureValueInfoProfileSpec extends FunSpec with Matchers
         val expected = false
 
         val pureValueInfoProfile = new PureValueInfoProfile(
+          mockScalaVirtualMachine,
           null
         )
 
@@ -304,6 +329,7 @@ class PureValueInfoProfileSpec extends FunSpec with Matchers
         val expected = false
 
         val pureValueInfoProfile = new PureValueInfoProfile(
+          mockScalaVirtualMachine,
           mock[Value]
         )
 
@@ -316,6 +342,7 @@ class PureValueInfoProfileSpec extends FunSpec with Matchers
         val expected = true
 
         val pureValueInfoProfile = new PureValueInfoProfile(
+          mockScalaVirtualMachine,
           mock[ObjectReference]
         )
 
@@ -330,6 +357,7 @@ class PureValueInfoProfileSpec extends FunSpec with Matchers
         val expected = false
 
         val pureValueInfoProfile = new PureValueInfoProfile(
+          mockScalaVirtualMachine,
           null
         )
 
@@ -342,6 +370,7 @@ class PureValueInfoProfileSpec extends FunSpec with Matchers
         val expected = false
 
         val pureValueInfoProfile = new PureValueInfoProfile(
+          mockScalaVirtualMachine,
           mock[Value]
         )
 
@@ -354,6 +383,7 @@ class PureValueInfoProfileSpec extends FunSpec with Matchers
         val expected = true
 
         val pureValueInfoProfile = new PureValueInfoProfile(
+          mockScalaVirtualMachine,
           mock[StringReference]
         )
 
@@ -368,6 +398,7 @@ class PureValueInfoProfileSpec extends FunSpec with Matchers
         val expected = false
 
         val pureValueInfoProfile = new PureValueInfoProfile(
+          mockScalaVirtualMachine,
           null
         )
 
@@ -380,6 +411,7 @@ class PureValueInfoProfileSpec extends FunSpec with Matchers
         val expected = false
 
         val pureValueInfoProfile = new PureValueInfoProfile(
+          mockScalaVirtualMachine,
           mock[Value]
         )
 
@@ -392,6 +424,7 @@ class PureValueInfoProfileSpec extends FunSpec with Matchers
         val expected = true
 
         val pureValueInfoProfile = new PureValueInfoProfile(
+          mockScalaVirtualMachine,
           mock[ArrayReference]
         )
 
@@ -406,6 +439,7 @@ class PureValueInfoProfileSpec extends FunSpec with Matchers
         val expected = true
 
         val pureValueInfoProfile = new PureValueInfoProfile(
+          mockScalaVirtualMachine,
           null
         )
 
@@ -418,6 +452,7 @@ class PureValueInfoProfileSpec extends FunSpec with Matchers
         val expected = false
 
         val pureValueInfoProfile = new PureValueInfoProfile(
+          mockScalaVirtualMachine,
           mock[Value]
         )
 

--- a/scala-debugger-api/src/test/scala/org/scaladebugger/api/virtualmachines/DummyScalaVirtualMachineSpec.scala
+++ b/scala-debugger-api/src/test/scala/org/scaladebugger/api/virtualmachines/DummyScalaVirtualMachineSpec.scala
@@ -41,6 +41,18 @@ class DummyScalaVirtualMachineSpec extends FunSpec with Matchers
       }
     }
 
+    describe("#cache") {
+      it("should return the same cache instance") {
+        val expected = dummyScalaVirtualMachine.cache
+
+        expected should not be (null)
+
+        val actual = dummyScalaVirtualMachine.cache
+
+        actual should be (expected)
+      }
+    }
+
     describe("#lowlevel") {
       it("should return a container of dummy managers") {
         val managerContainer = dummyScalaVirtualMachine.lowlevel

--- a/scala-debugger-api/src/test/scala/org/scaladebugger/api/virtualmachines/ObjectCacheSpec.scala
+++ b/scala-debugger-api/src/test/scala/org/scaladebugger/api/virtualmachines/ObjectCacheSpec.scala
@@ -1,0 +1,204 @@
+package org.scaladebugger.api.virtualmachines
+
+import com.sun.jdi.{ObjectReference, VMCannotBeModifiedException}
+import org.scaladebugger.api.profiles.traits.info.ObjectInfoProfile
+import org.scalamock.scalatest.MockFactory
+import org.scalatest.{FunSpec, Matchers, ParallelTestExecution}
+
+class ObjectCacheSpec extends FunSpec with Matchers
+  with ParallelTestExecution with MockFactory
+{
+  private val TestUniqueId = 1234L
+  private val internalCache =
+    new collection.mutable.HashMap[Long, ObjectInfoProfile]()
+  private val objectCache = new ObjectCache(internalCache)
+
+  describe("ObjectCache") {
+    describe("#save") {
+      it("should cache the object using its unique id") {
+        val obj = mock[ObjectInfoProfile]
+        (obj.uniqueId _).expects().returning(TestUniqueId).once()
+
+        objectCache.save(obj)
+
+        internalCache.keySet should contain (TestUniqueId)
+      }
+
+      it("should return Some(id) if successfully cached") {
+        val expected = Some(TestUniqueId)
+
+        val obj = mock[ObjectInfoProfile]
+        (obj.uniqueId _).expects().returning(TestUniqueId).once()
+
+        val actual = objectCache.save(obj)
+
+        actual should be (expected)
+      }
+
+      it("should return None if unable to retrieve the id to cache the object") {
+        val expected = None
+
+        val obj = mock[ObjectInfoProfile]
+        (obj.uniqueId _).expects().throwing(new Throwable).once()
+
+        val actual = objectCache.save(obj)
+
+        actual should be (expected)
+      }
+    }
+
+    describe("#load") {
+      it("should return None if no object with matching id is cached") {
+        val expected = None
+
+        val actual = objectCache.load(TestUniqueId)
+
+        actual should be (expected)
+      }
+
+      it("should return None and remove the cached object if it was collected") {
+        val expected = None
+
+        val obj = mock[ObjectInfoProfile]
+        internalCache.put(TestUniqueId, obj)
+
+        val mockObjectReference = mock[ObjectReference]
+        (obj.toJdiInstance _).expects().returning(mockObjectReference).once()
+
+        (mockObjectReference.isCollected _).expects().returning(true).once()
+
+        val actual = objectCache.load(TestUniqueId)
+
+        actual should be (expected)
+        internalCache.get(TestUniqueId) should be (None)
+      }
+
+      it("should return None and remove the cached object if failed to determine if collected") {
+        val expected = None
+
+        val obj = mock[ObjectInfoProfile]
+        internalCache.put(TestUniqueId, obj)
+
+        val mockObjectReference = mock[ObjectReference]
+        (obj.toJdiInstance _).expects().returning(mockObjectReference).once()
+
+        (mockObjectReference.isCollected _).expects()
+          .throwing(new VMCannotBeModifiedException()).once()
+
+        val actual = objectCache.load(TestUniqueId)
+
+        actual should be (expected)
+        internalCache.get(TestUniqueId) should be (None)
+      }
+
+      it("should return Some(object) if the cached object was not collected") {
+        val expected = Some(mock[ObjectInfoProfile])
+
+        val obj = expected.get
+        internalCache.put(TestUniqueId, obj)
+
+        val mockObjectReference = mock[ObjectReference]
+        (obj.toJdiInstance _).expects().returning(mockObjectReference).once()
+
+        (mockObjectReference.isCollected _).expects().returning(false).once()
+
+        val actual = objectCache.load(TestUniqueId)
+
+        actual should be (expected)
+        internalCache.get(TestUniqueId) should be (expected)
+      }
+    }
+
+    describe("#has(id)") {
+      it("should return true if an object with the provided id is in the cache") {
+        val expected = true
+
+        internalCache.put(TestUniqueId, mock[ObjectInfoProfile])
+
+        val actual = objectCache.has(TestUniqueId)
+
+        actual should be (expected)
+      }
+
+      it("should return false if no object with the provided id is in the cache") {
+        val expected = false
+
+        val actual = objectCache.has(TestUniqueId)
+
+        actual should be (expected)
+      }
+    }
+
+    describe("#has(object)") {
+      it("should return true if the object with the provided id is in the cache") {
+        val expected = true
+
+        val mockObject = mock[ObjectInfoProfile]
+        internalCache.put(TestUniqueId, mockObject)
+
+        (mockObject.uniqueId _).expects().returning(TestUniqueId).once()
+
+        val actual = objectCache.has(mockObject)
+
+        actual should be (expected)
+      }
+
+      it("should return false if unable to get the unique id from the object") {
+        val expected = false
+
+        val mockObject = mock[ObjectInfoProfile]
+        internalCache.put(TestUniqueId, mockObject)
+
+        (mockObject.uniqueId _).expects()
+          .throwing(new VMCannotBeModifiedException()).once()
+
+        val actual = objectCache.has(mockObject)
+
+        actual should be (expected)
+      }
+
+      it("should return false if no object with the provided id is in the cache") {
+        val expected = false
+
+        val mockObject = mock[ObjectInfoProfile]
+        (mockObject.uniqueId _).expects().returning(TestUniqueId).once()
+
+        val actual = objectCache.has(mockObject)
+
+        actual should be (expected)
+      }
+    }
+
+    describe("#remove") {
+      it("should remove the cached object and return Some(object)") {
+        val expected = Some(mock[ObjectInfoProfile])
+
+        internalCache.put(TestUniqueId, expected.get)
+
+        val actual = objectCache.remove(TestUniqueId)
+
+        actual should be (expected)
+      }
+
+      it("should return None if no object with the id is cached") {
+        val expected = None
+
+        val actual = objectCache.remove(TestUniqueId)
+
+        actual should be (expected)
+      }
+    }
+
+    describe("#clear") {
+      it("should remove all cached objects") {
+        internalCache.put(TestUniqueId, mock[ObjectInfoProfile])
+        internalCache.put(TestUniqueId + 1, mock[ObjectInfoProfile])
+        internalCache.put(TestUniqueId + 2, mock[ObjectInfoProfile])
+
+        objectCache.clear()
+
+        internalCache should be (empty)
+      }
+    }
+  }
+}

--- a/scala-debugger-api/src/test/scala/org/scaladebugger/api/virtualmachines/ScalaVirtualMachineSpec.scala
+++ b/scala-debugger-api/src/test/scala/org/scaladebugger/api/virtualmachines/ScalaVirtualMachineSpec.scala
@@ -21,6 +21,7 @@ class ScalaVirtualMachineSpec extends FunSpec with Matchers
     _profileManager: ProfileManager
   ) =
     new Object with ScalaVirtualMachine {
+      override val cache: ObjectCache = null
       override val lowlevel: ManagerContainer = managerContainer
 
       override def initialize(startProcessingEvents: Boolean): Unit = {}

--- a/scala-debugger-api/src/test/scala/org/scaladebugger/api/virtualmachines/StandardScalaVirtualMachineSpec.scala
+++ b/scala-debugger-api/src/test/scala/org/scaladebugger/api/virtualmachines/StandardScalaVirtualMachineSpec.scala
@@ -22,6 +22,18 @@ class StandardScalaVirtualMachineSpec extends FunSpec with Matchers
   )
 
   describe("ScalaVirtualMachine") {
+    describe("#cache") {
+      it("should return the same cache instance") {
+        val expected = scalaVirtualMachine.cache
+
+        expected should not be (null)
+
+        val actual = scalaVirtualMachine.cache
+
+        actual should be(expected)
+      }
+    }
+
     describe("#register") {
       it("should invoke the underlying profile manager") {
         val testName = "some name"

--- a/scala-debugger-api/src/test/scala/test/InfoTestClasses.scala
+++ b/scala-debugger-api/src/test/scala/test/InfoTestClasses.scala
@@ -3,6 +3,7 @@ package test
 import com.sun.jdi._
 import org.scaladebugger.api.lowlevel.JDIArgument
 import org.scaladebugger.api.profiles.traits.info._
+import org.scaladebugger.api.virtualmachines.ScalaVirtualMachine
 
 import scala.util.Try
 
@@ -17,6 +18,7 @@ object InfoTestClasses {
   private def throwException() = throw DefaultException
 
   class TestThreadInfoProfile extends TestObjectInfoProfile with ThreadInfoProfile {
+    override def scalaVirtualMachine: ScalaVirtualMachine = throwException()
     override def getFrames: Seq[FrameInfoProfile] = throwException()
     override def name: String = throwException()
     override def getFrame(index: Int): FrameInfoProfile = throwException()
@@ -25,6 +27,7 @@ object InfoTestClasses {
   }
 
   class TestLocationInfoProfile extends LocationInfoProfile {
+    override def scalaVirtualMachine: ScalaVirtualMachine = throwException()
     override def toJdiInstance: Location = throwException()
     override def getSourcePath: String = throwException()
     override def getLineNumber: Int = throwException()
@@ -35,6 +38,7 @@ object InfoTestClasses {
   }
 
   class TestValueInfoProfile extends ValueInfoProfile {
+    override def scalaVirtualMachine: ScalaVirtualMachine = throwException()
     override def typeName: String = throwException()
     override def isObject: Boolean = throwException()
     override def isPrimitive: Boolean = throwException()
@@ -50,6 +54,7 @@ object InfoTestClasses {
   }
 
   class TestVariableInfoProfile extends VariableInfoProfile {
+    override def scalaVirtualMachine: ScalaVirtualMachine = throwException()
     override def name: String = throwException()
     override def toValue: ValueInfoProfile = throwException()
     override def setValue(value: AnyVal): AnyVal = throwException()
@@ -61,6 +66,7 @@ object InfoTestClasses {
   }
 
   class TestObjectInfoProfile extends TestValueInfoProfile with ObjectInfoProfile {
+    override def scalaVirtualMachine: ScalaVirtualMachine = throwException()
     override def uniqueId: Long = throwException()
     override def invoke(methodInfoProfile: MethodInfoProfile, arguments: Seq[Any], jdiArguments: JDIArgument*): ValueInfoProfile = throwException()
     override def invoke(methodName: String, parameterTypeNames: Seq[String], arguments: Seq[Any], jdiArguments: JDIArgument*): ValueInfoProfile = throwException()
@@ -73,6 +79,7 @@ object InfoTestClasses {
   }
 
   class TestMethodInfoProfile extends MethodInfoProfile {
+    override def scalaVirtualMachine: ScalaVirtualMachine = throwException()
     override def name: String = throwException()
     override def getReturnTypeName: String = throwException()
     override def getParameterTypeNames: Seq[String] = throwException()
@@ -86,6 +93,7 @@ object InfoTestClasses {
   }
 
   class TestFrameInfoProfile extends FrameInfoProfile {
+    override def scalaVirtualMachine: ScalaVirtualMachine = throwException()
     override def index: Int = throwException()
     override def getThisObject: ObjectInfoProfile = throwException()
     override def getCurrentThread: ThreadInfoProfile = throwException()
@@ -101,6 +109,7 @@ object InfoTestClasses {
   }
 
   class TestArrayInfoProfile extends TestObjectInfoProfile with ArrayInfoProfile {
+    override def scalaVirtualMachine: ScalaVirtualMachine = throwException()
     override def length: Int = throwException()
     override def getValue(index: Int): ValueInfoProfile = throwException()
     override def setValues(index: Int, values: Seq[Any], srcIndex: Int, length: Int): Seq[Any] = throwException()
@@ -112,6 +121,7 @@ object InfoTestClasses {
   }
 
   class TestPrimitiveInfoProfile extends TestValueInfoProfile with PrimitiveInfoProfile {
+    override def scalaVirtualMachine: ScalaVirtualMachine = throwException()
     override def toLocalValue: AnyVal = throwException()
     override def isBoolean: Boolean = throwException()
     override def isFloat: Boolean = throwException()
@@ -125,6 +135,7 @@ object InfoTestClasses {
   }
 
   class TestReferenceTypeInfoProfile extends ReferenceTypeInfoProfile {
+    override def scalaVirtualMachine: ScalaVirtualMachine = throwException()
     override def toJdiInstance: ReferenceType = throwException()
     override def isFinal: Boolean = throwException()
     override def isPrepared: Boolean = throwException()


### PR DESCRIPTION
Resolves #198.

1. Added ObjectCache class
2. Added cache variable hanging off of ScalaVirtualMachine (needed for
   profiles to have access)
3. Added cache/uncache DSL methods on object info profiles
4. Removed acyclic checks due to new cyclical ScalaVirtualMachine in
   profiles