### PR TITLE
Updated base image for Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ensime/ensime:v2.x
+FROM ensime/ensime:v2.x-cache
 MAINTAINER Chip Senkbeil <chip.senkbeil@gmail.com>
 
 ENV GIT_REPO https://github.com/ensime/scala-debugger.git


### PR DESCRIPTION
@fommil indicated that the base image has changed from `ensime/ensime:v2.x` to `ensime/ensime:v2.x-cache`. This will update the Dockerfile that generates the cached Scala Debugger image.