### PR TITLE
Add setValue/setValues support for ValueInfoProfile

### DIFF
--- a/scala-debugger-api/src/it/scala/org/scaladebugger/api/profiles/pure/info/PureArrayInfoProfileIntegrationSpec.scala
+++ b/scala-debugger-api/src/it/scala/org/scaladebugger/api/profiles/pure/info/PureArrayInfoProfileIntegrationSpec.scala
@@ -154,7 +154,8 @@ class PureArrayInfoProfileIntegrationSpec extends FunSpec with Matchers
             .variable("i").toValue.toArray
 
           // Set element at position 1 to source element 2 (12)
-          array.setValues(1, Seq(10, 11, 12), 2, 1) should be (Seq(12))
+          val results = array.setValues(1, Seq(10, 11, 12), 2, 1).map(_.toLocalValue)
+          results should be (Seq(12))
         })
       }
     }
@@ -177,7 +178,8 @@ class PureArrayInfoProfileIntegrationSpec extends FunSpec with Matchers
             .thread(t.get).topFrame
             .variable("i").toValue.toArray
 
-          array.setValues(Seq(10, 11, 12)) should be (Seq(10, 11, 12))
+          val results = array.setValues(Seq(10, 11, 12)).map(_.toLocalValue)
+          results should be (Seq(10, 11, 12))
         })
       }
     }

--- a/scala-debugger-api/src/it/scala/org/scaladebugger/api/profiles/pure/info/PureFieldInfoProfileIntegrationSpec.scala
+++ b/scala-debugger-api/src/it/scala/org/scaladebugger/api/profiles/pure/info/PureFieldInfoProfileIntegrationSpec.scala
@@ -130,7 +130,7 @@ class PureFieldInfoProfileIntegrationSpec extends FunSpec with Matchers
             .thread(t.get).topFrame
             .variable("z1")
 
-          field.setValue(333) should be (333)
+          field.setValue(333).toLocalValue should be (333)
         })
       }
     }
@@ -153,7 +153,7 @@ class PureFieldInfoProfileIntegrationSpec extends FunSpec with Matchers
             .thread(t.get).topFrame
             .variable("z2")
 
-          field.setValue("some value") should be ("some value")
+          field.setValue("some value").toLocalValue should be ("some value")
         })
       }
     }

--- a/scala-debugger-api/src/it/scala/org/scaladebugger/api/profiles/pure/info/PureLocalVariableInfoProfileIntegrationSpec.scala
+++ b/scala-debugger-api/src/it/scala/org/scaladebugger/api/profiles/pure/info/PureLocalVariableInfoProfileIntegrationSpec.scala
@@ -134,7 +134,7 @@ class PureLocalVariableInfoProfileIntegrationSpec extends FunSpec with Matchers
             .thread(t.get).topFrame
             .variable("g")
 
-          variable.setValue(888.0) should be (888.0)
+          variable.setValue(888.0).toLocalValue should be (888.0)
         })
       }
     }

--- a/scala-debugger-api/src/main/scala/org/scaladebugger/api/profiles/pure/PureDebugProfile.scala
+++ b/scala-debugger-api/src/main/scala/org/scaladebugger/api/profiles/pure/PureDebugProfile.scala
@@ -6,7 +6,7 @@ import org.scaladebugger.api.profiles.pure.breakpoints.PureBreakpointProfile
 import org.scaladebugger.api.profiles.pure.classes.{PureClassPrepareProfile, PureClassUnloadProfile}
 import org.scaladebugger.api.profiles.pure.events.PureEventProfile
 import org.scaladebugger.api.profiles.pure.exceptions.PureExceptionProfile
-import org.scaladebugger.api.profiles.pure.info.{PureGrabInfoProfile, PureMiscInfoProfile}
+import org.scaladebugger.api.profiles.pure.info.{PureCreateInfoProfile, PureGrabInfoProfile, PureMiscInfoProfile}
 import org.scaladebugger.api.profiles.pure.methods.{PureMethodEntryProfile, PureMethodExitProfile}
 import org.scaladebugger.api.profiles.pure.monitors.{PureMonitorContendedEnterProfile, PureMonitorContendedEnteredProfile, PureMonitorWaitProfile, PureMonitorWaitedProfile}
 import org.scaladebugger.api.profiles.pure.steps.PureStepProfile
@@ -44,6 +44,7 @@ class PureDebugProfile(
   with PureBreakpointProfile
   with PureClassPrepareProfile
   with PureClassUnloadProfile
+  with PureCreateInfoProfile
   with PureEventProfile
   with PureExceptionProfile
   with PureGrabInfoProfile

--- a/scala-debugger-api/src/main/scala/org/scaladebugger/api/profiles/pure/info/PureClassLoaderInfoProfile.scala
+++ b/scala-debugger-api/src/main/scala/org/scaladebugger/api/profiles/pure/info/PureClassLoaderInfoProfile.scala
@@ -25,7 +25,7 @@ class PureClassLoaderInfoProfile(
   override val scalaVirtualMachine: ScalaVirtualMachine,
   private val _classLoaderReference: ClassLoaderReference
 )(
-  private val _virtualMachine: VirtualMachine = _classLoaderReference.virtualMachine(),
+  override protected val _virtualMachine: VirtualMachine = _classLoaderReference.virtualMachine(),
   private val _threadReference: ThreadReference = _classLoaderReference.owningThread(),
   private val _referenceType: ReferenceType = _classLoaderReference.referenceType()
 ) extends PureObjectInfoProfile(scalaVirtualMachine, _classLoaderReference)(

--- a/scala-debugger-api/src/main/scala/org/scaladebugger/api/profiles/pure/info/PureClassObjectInfoProfile.scala
+++ b/scala-debugger-api/src/main/scala/org/scaladebugger/api/profiles/pure/info/PureClassObjectInfoProfile.scala
@@ -22,7 +22,7 @@ class PureClassObjectInfoProfile(
   override val scalaVirtualMachine: ScalaVirtualMachine,
   private val _classObjectReference: ClassObjectReference
 )(
-  private val _virtualMachine: VirtualMachine = _classObjectReference.virtualMachine(),
+  override protected val _virtualMachine: VirtualMachine = _classObjectReference.virtualMachine(),
   private val _threadReference: ThreadReference = _classObjectReference.owningThread(),
   private val _referenceType: ReferenceType = _classObjectReference.referenceType()
 ) extends PureObjectInfoProfile(scalaVirtualMachine, _classObjectReference)(

--- a/scala-debugger-api/src/main/scala/org/scaladebugger/api/profiles/pure/info/PureCreateInfoProfile.scala
+++ b/scala-debugger-api/src/main/scala/org/scaladebugger/api/profiles/pure/info/PureCreateInfoProfile.scala
@@ -1,0 +1,41 @@
+package org.scaladebugger.api.profiles.pure.info
+
+//import acyclic.file
+
+import com.sun.jdi.{ReferenceType, Value}
+import org.scaladebugger.api.lowlevel.classes.ClassManager
+import org.scaladebugger.api.lowlevel.utils.JDIHelperMethods
+import org.scaladebugger.api.profiles.traits.info.{CreateInfoProfile, MiscInfoProfile, ReferenceTypeInfoProfile, ValueInfoProfile}
+import org.scaladebugger.api.virtualmachines.ScalaVirtualMachine
+
+/**
+ * Represents a pure profile for creating data that adds no extra logic
+ * on top of the standard JDI.
+ */
+trait PureCreateInfoProfile extends CreateInfoProfile with JDIHelperMethods {
+  protected val scalaVirtualMachine: ScalaVirtualMachine
+
+  /**
+   * Creates the provided value on the remote JVM.
+   *
+   * @param value The value to create (mirror) on the remote JVM
+   * @return The information about the remote value
+   */
+  override def createRemotely(value: AnyVal): ValueInfoProfile = {
+    import org.scaladebugger.api.lowlevel.wrappers.Implicits._
+    createNewValueProfile(_virtualMachine.mirrorOf(value))
+  }
+
+  /**
+   * Creates the provided value on the remote JVM.
+   *
+   * @param value The value to create (mirror) on the remote JVM
+   * @return The information about the remote value
+   */
+  override def createRemotely(value: String): ValueInfoProfile = {
+    createNewValueProfile(_virtualMachine.mirrorOf(value))
+  }
+
+  protected def createNewValueProfile(value: Value): ValueInfoProfile =
+    new PureValueInfoProfile(scalaVirtualMachine, value)
+}

--- a/scala-debugger-api/src/main/scala/org/scaladebugger/api/profiles/pure/info/PureFieldInfoProfile.scala
+++ b/scala-debugger-api/src/main/scala/org/scaladebugger/api/profiles/pure/info/PureFieldInfoProfile.scala
@@ -2,7 +2,7 @@ package org.scaladebugger.api.profiles.pure.info
 //import acyclic.file
 
 import com.sun.jdi._
-import org.scaladebugger.api.profiles.traits.info.{TypeInfoProfile, ValueInfoProfile, VariableInfoProfile}
+import org.scaladebugger.api.profiles.traits.info._
 import org.scaladebugger.api.virtualmachines.ScalaVirtualMachine
 
 import scala.util.Try
@@ -24,9 +24,8 @@ class PureFieldInfoProfile(
   private val _container: Either[ObjectReference, ReferenceType],
   private val _field: Field
 )(
-  private val _virtualMachine: VirtualMachine = _field.virtualMachine()
-) extends VariableInfoProfile {
-
+  protected val _virtualMachine: VirtualMachine = _field.virtualMachine()
+) extends VariableInfoProfile with PureCreateInfoProfile {
   /**
    * Returns the JDI representation this profile instance wraps.
    *
@@ -77,28 +76,16 @@ class PureFieldInfoProfile(
   override def isLocal: Boolean = false
 
   /**
-   * Sets the primitive value of this variable.
+   * Sets the value of this variable using info about another remote value.
    *
-   * @param value The new value for the variable
-   * @return The new value
+   * @param valueInfo The remote value to set for the variable
+   * @return The info for the variable's new value
    */
-  override def setValue(value: AnyVal): AnyVal = {
-    import org.scaladebugger.api.lowlevel.wrappers.Implicits._
-    val mirrorValue = _virtualMachine.mirrorOf(value)
-    setFieldValue(mirrorValue)
-    value
-  }
-
-  /**
-   * Sets the string value of this variable.
-   *
-   * @param value The new value for the variable
-   * @return The new value
-   */
-  override def setValue(value: String): String = {
-    val mirrorValue = _virtualMachine.mirrorOf(value)
-    setFieldValue(mirrorValue)
-    value
+  override def setValueFromInfo(
+    valueInfo: ValueInfoProfile
+  ): ValueInfoProfile = {
+    setFieldValue(valueInfo.toJdiInstance)
+    valueInfo
   }
 
   private def setFieldValue(value: Value): Unit = _container match {

--- a/scala-debugger-api/src/main/scala/org/scaladebugger/api/profiles/pure/info/PureMiscInfoProfile.scala
+++ b/scala-debugger-api/src/main/scala/org/scaladebugger/api/profiles/pure/info/PureMiscInfoProfile.scala
@@ -28,27 +28,6 @@ trait PureMiscInfoProfile extends MiscInfoProfile with JDIHelperMethods {
     classManager.linesAndLocationsForFile(fileName).map(_.keys.toSeq.sorted)
 
   /**
-   * Creates the provided value on the remote JVM.
-   *
-   * @param value The value to create (mirror) on the remote JVM
-   * @return The information about the remote value
-   */
-  override def createRemotely(value: AnyVal): ValueInfoProfile = {
-    import org.scaladebugger.api.lowlevel.wrappers.Implicits._
-    miscNewValueProfile(_virtualMachine.mirrorOf(value))
-  }
-
-  /**
-   * Creates the provided value on the remote JVM.
-   *
-   * @param value The value to create (mirror) on the remote JVM
-   * @return The information about the remote value
-   */
-  override def createRemotely(value: String): ValueInfoProfile = {
-    miscNewValueProfile(_virtualMachine.mirrorOf(value))
-  }
-
-  /**
    * Retrieves all source paths for the given source name.
    *
    * @example nameToPaths("file.scala") yields
@@ -84,7 +63,4 @@ trait PureMiscInfoProfile extends MiscInfoProfile with JDIHelperMethods {
     scalaVirtualMachine,
     referenceType
   )
-
-  protected def miscNewValueProfile(value: Value): ValueInfoProfile =
-    new PureValueInfoProfile(scalaVirtualMachine, value)
 }

--- a/scala-debugger-api/src/main/scala/org/scaladebugger/api/profiles/pure/info/PureObjectInfoProfile.scala
+++ b/scala-debugger-api/src/main/scala/org/scaladebugger/api/profiles/pure/info/PureObjectInfoProfile.scala
@@ -25,7 +25,7 @@ class PureObjectInfoProfile(
   override val scalaVirtualMachine: ScalaVirtualMachine,
   private val _objectReference: ObjectReference
 )(
-  private val _virtualMachine: VirtualMachine = _objectReference.virtualMachine(),
+  protected val _virtualMachine: VirtualMachine = _objectReference.virtualMachine(),
   private val _threadReference: ThreadReference = _objectReference.owningThread(),
   private val _referenceType: ReferenceType = _objectReference.referenceType()
 ) extends PureValueInfoProfile(

--- a/scala-debugger-api/src/main/scala/org/scaladebugger/api/profiles/pure/info/PureThreadInfoProfile.scala
+++ b/scala-debugger-api/src/main/scala/org/scaladebugger/api/profiles/pure/info/PureThreadInfoProfile.scala
@@ -22,7 +22,7 @@ class PureThreadInfoProfile(
   override val scalaVirtualMachine: ScalaVirtualMachine,
   private val _threadReference: ThreadReference
 )(
-  private val _virtualMachine: VirtualMachine = _threadReference.virtualMachine(),
+  override protected val _virtualMachine: VirtualMachine = _threadReference.virtualMachine(),
   private val _referenceType: ReferenceType = _threadReference.referenceType()
 ) extends PureObjectInfoProfile(scalaVirtualMachine, _threadReference)(
   _virtualMachine = _virtualMachine,

--- a/scala-debugger-api/src/main/scala/org/scaladebugger/api/profiles/swappable/SwappableDebugProfile.scala
+++ b/scala-debugger-api/src/main/scala/org/scaladebugger/api/profiles/swappable/SwappableDebugProfile.scala
@@ -6,12 +6,12 @@ import org.scaladebugger.api.profiles.swappable.breakpoints.SwappableBreakpointP
 import org.scaladebugger.api.profiles.swappable.classes.{SwappableClassPrepareProfile, SwappableClassUnloadProfile}
 import org.scaladebugger.api.profiles.swappable.events.SwappableEventProfile
 import org.scaladebugger.api.profiles.swappable.exceptions.SwappableExceptionProfile
-import org.scaladebugger.api.profiles.swappable.info.{SwappableGrabInfoProfile, SwappableMiscInfoProfile}
+import org.scaladebugger.api.profiles.swappable.info.{SwappableCreateInfoProfile, SwappableGrabInfoProfile, SwappableMiscInfoProfile}
 import org.scaladebugger.api.profiles.swappable.methods.{SwappableMethodEntryProfile, SwappableMethodExitProfile}
-import org.scaladebugger.api.profiles.swappable.monitors.{SwappableMonitorContendedEnteredProfile, SwappableMonitorContendedEnterProfile, SwappableMonitorWaitedProfile, SwappableMonitorWaitProfile}
+import org.scaladebugger.api.profiles.swappable.monitors.{SwappableMonitorContendedEnterProfile, SwappableMonitorContendedEnteredProfile, SwappableMonitorWaitProfile, SwappableMonitorWaitedProfile}
 import org.scaladebugger.api.profiles.swappable.steps.SwappableStepProfile
 import org.scaladebugger.api.profiles.swappable.threads.{SwappableThreadDeathProfile, SwappableThreadStartProfile}
-import org.scaladebugger.api.profiles.swappable.vm.{SwappableVMStartProfile, SwappableVMDisconnectProfile, SwappableVMDeathProfile}
+import org.scaladebugger.api.profiles.swappable.vm.{SwappableVMDeathProfile, SwappableVMDisconnectProfile, SwappableVMStartProfile}
 import org.scaladebugger.api.profiles.swappable.watchpoints.{SwappableAccessWatchpointProfile, SwappableModificationWatchpointProfile}
 import org.scaladebugger.api.profiles.traits.DebugProfile
 
@@ -33,6 +33,7 @@ trait SwappableDebugProfile
   with SwappableBreakpointProfile
   with SwappableClassPrepareProfile
   with SwappableClassUnloadProfile
+  with SwappableCreateInfoProfile
   with SwappableEventProfile
   with SwappableExceptionProfile
   with SwappableGrabInfoProfile

--- a/scala-debugger-api/src/main/scala/org/scaladebugger/api/profiles/swappable/info/SwappableCreateInfoProfile.scala
+++ b/scala-debugger-api/src/main/scala/org/scaladebugger/api/profiles/swappable/info/SwappableCreateInfoProfile.scala
@@ -1,0 +1,21 @@
+package org.scaladebugger.api.profiles.swappable.info
+
+//import acyclic.file
+import org.scaladebugger.api.profiles.swappable.SwappableDebugProfileManagement
+import org.scaladebugger.api.profiles.traits.info.{CreateInfoProfile, MiscInfoProfile, ValueInfoProfile}
+
+/**
+ * Represents a swappable profile for creating data that redirects the
+ * invocation to another profile.
+ */
+trait SwappableCreateInfoProfile extends CreateInfoProfile {
+  this: SwappableDebugProfileManagement =>
+
+  override def createRemotely(value: AnyVal): ValueInfoProfile = {
+    withCurrentProfile.createRemotely(value)
+  }
+
+  override def createRemotely(value: String): ValueInfoProfile = {
+    withCurrentProfile.createRemotely(value)
+  }
+}

--- a/scala-debugger-api/src/main/scala/org/scaladebugger/api/profiles/swappable/info/SwappableMiscInfoProfile.scala
+++ b/scala-debugger-api/src/main/scala/org/scaladebugger/api/profiles/swappable/info/SwappableMiscInfoProfile.scala
@@ -14,14 +14,6 @@ trait SwappableMiscInfoProfile extends MiscInfoProfile {
     withCurrentProfile.availableLinesForFile(fileName)
   }
 
-  override def createRemotely(value: AnyVal): ValueInfoProfile = {
-    withCurrentProfile.createRemotely(value)
-  }
-
-  override def createRemotely(value: String): ValueInfoProfile = {
-    withCurrentProfile.createRemotely(value)
-  }
-
   override def sourceNameToPaths(sourceName: String): Seq[String] = {
     withCurrentProfile.sourceNameToPaths(sourceName)
   }

--- a/scala-debugger-api/src/main/scala/org/scaladebugger/api/profiles/traits/DebugProfile.scala
+++ b/scala-debugger-api/src/main/scala/org/scaladebugger/api/profiles/traits/DebugProfile.scala
@@ -5,12 +5,12 @@ import org.scaladebugger.api.profiles.traits.breakpoints.BreakpointProfile
 import org.scaladebugger.api.profiles.traits.classes.{ClassPrepareProfile, ClassUnloadProfile}
 import org.scaladebugger.api.profiles.traits.events.EventProfile
 import org.scaladebugger.api.profiles.traits.exceptions.ExceptionProfile
-import org.scaladebugger.api.profiles.traits.info.{GrabInfoProfile, MiscInfoProfile}
+import org.scaladebugger.api.profiles.traits.info.{CreateInfoProfile, GrabInfoProfile, MiscInfoProfile}
 import org.scaladebugger.api.profiles.traits.methods.{MethodEntryProfile, MethodExitProfile}
 import org.scaladebugger.api.profiles.traits.monitors.{MonitorContendedEnterProfile, MonitorContendedEnteredProfile, MonitorWaitProfile, MonitorWaitedProfile}
 import org.scaladebugger.api.profiles.traits.steps.StepProfile
 import org.scaladebugger.api.profiles.traits.threads.{ThreadDeathProfile, ThreadStartProfile}
-import org.scaladebugger.api.profiles.traits.vm.{VMDisconnectProfile, VMStartProfile, VMDeathProfile}
+import org.scaladebugger.api.profiles.traits.vm.{VMDeathProfile, VMDisconnectProfile, VMStartProfile}
 import org.scaladebugger.api.profiles.traits.watchpoints.{AccessWatchpointProfile, ModificationWatchpointProfile}
 
 /**
@@ -22,6 +22,7 @@ trait DebugProfile
   with BreakpointProfile
   with ClassPrepareProfile
   with ClassUnloadProfile
+  with CreateInfoProfile
   with EventProfile
   with ExceptionProfile
   with GrabInfoProfile

--- a/scala-debugger-api/src/main/scala/org/scaladebugger/api/profiles/traits/info/CreateInfoProfile.scala
+++ b/scala-debugger-api/src/main/scala/org/scaladebugger/api/profiles/traits/info/CreateInfoProfile.scala
@@ -1,0 +1,46 @@
+package org.scaladebugger.api.profiles.traits.info
+
+import scala.util.Try
+//import acyclic.file
+
+/**
+ * Represents the interface that needs to be implemented to provide
+ * ability to create data using a specific debug profile.
+ */
+trait CreateInfoProfile {
+  /**
+   * Creates the provided value on the remote JVM.
+   *
+   * @param value The value to create (mirror) on the remote JVM
+   * @return The information about the remote value
+   */
+  def createRemotely(value: AnyVal): ValueInfoProfile
+
+  /**
+   * Creates the provided value on the remote JVM.
+   *
+   * @param value The value to create (mirror) on the remote JVM
+   * @return Success containing the information about the remote value,
+   *         otherwise a failure
+   */
+  def tryCreateRemotely(value: AnyVal): Try[ValueInfoProfile] =
+    Try(createRemotely(value))
+
+  /**
+   * Creates the provided value on the remote JVM.
+   *
+   * @param value The value to create (mirror) on the remote JVM
+   * @return The information about the remote value
+   */
+  def createRemotely(value: String): ValueInfoProfile
+
+  /**
+   * Creates the provided value on the remote JVM.
+   *
+   * @param value The value to create (mirror) on the remote JVM
+   * @return Success containing the information about the remote value,
+   *         otherwise a failure
+   */
+  def tryCreateRemotely(value: String): Try[ValueInfoProfile] =
+    Try(createRemotely(value))
+}

--- a/scala-debugger-api/src/main/scala/org/scaladebugger/api/profiles/traits/info/IndexedVariableInfoProfile.scala
+++ b/scala-debugger-api/src/main/scala/org/scaladebugger/api/profiles/traits/info/IndexedVariableInfoProfile.scala
@@ -6,7 +6,10 @@ package org.scaladebugger.api.profiles.traits.info
  * Represents the interface for variable-based interaction with indexed
  * location information.
  */
-trait IndexedVariableInfoProfile extends VariableInfoProfile with CommonInfoProfile {
+trait IndexedVariableInfoProfile
+  extends VariableInfoProfile with CreateInfoProfile with CommonInfoProfile
+{
+
   /**
    * Returns the frame containing this variable.
    *

--- a/scala-debugger-api/src/main/scala/org/scaladebugger/api/profiles/traits/info/MiscInfoProfile.scala
+++ b/scala-debugger-api/src/main/scala/org/scaladebugger/api/profiles/traits/info/MiscInfoProfile.scala
@@ -18,42 +18,6 @@ trait MiscInfoProfile {
   def availableLinesForFile(fileName: String): Option[Seq[Int]]
 
   /**
-   * Creates the provided value on the remote JVM.
-   *
-   * @param value The value to create (mirror) on the remote JVM
-   * @return The information about the remote value
-   */
-  def createRemotely(value: AnyVal): ValueInfoProfile
-
-  /**
-   * Creates the provided value on the remote JVM.
-   *
-   * @param value The value to create (mirror) on the remote JVM
-   * @return Success containing the information about the remote value,
-   *         otherwise a failure
-   */
-  def tryCreateRemotely(value: AnyVal): Try[ValueInfoProfile] =
-    Try(createRemotely(value))
-
-  /**
-   * Creates the provided value on the remote JVM.
-   *
-   * @param value The value to create (mirror) on the remote JVM
-   * @return The information about the remote value
-   */
-  def createRemotely(value: String): ValueInfoProfile
-
-  /**
-   * Creates the provided value on the remote JVM.
-   *
-   * @param value The value to create (mirror) on the remote JVM
-   * @return Success containing the information about the remote value,
-   *         otherwise a failure
-   */
-  def tryCreateRemotely(value: String): Try[ValueInfoProfile] =
-    Try(createRemotely(value))
-
-  /**
    * Retrieves all source paths for the given source name.
    *
    * @example nameToPaths("file.scala") yields

--- a/scala-debugger-api/src/main/scala/org/scaladebugger/api/profiles/traits/info/UnsupportedTypeException.scala
+++ b/scala-debugger-api/src/main/scala/org/scaladebugger/api/profiles/traits/info/UnsupportedTypeException.scala
@@ -1,0 +1,11 @@
+package org.scaladebugger.api.profiles.traits.info
+
+/**
+ * Represents an exception that occurs when a local value is trying to be
+ * sent remotely, but the local value has a type that is unsupported for
+ * remote creation.
+ *
+ * @param value The local value with the unsupported type
+ */
+class UnsupportedTypeException(private val value: Any)
+  extends Exception(s"Unsupported type: ${value.getClass.getName}")

--- a/scala-debugger-api/src/main/scala/org/scaladebugger/api/profiles/traits/info/VariableInfoProfile.scala
+++ b/scala-debugger-api/src/main/scala/org/scaladebugger/api/profiles/traits/info/VariableInfoProfile.scala
@@ -8,7 +8,7 @@ import scala.util.Try
 /**
  * Represents the interface for variable-based interaction.
  */
-trait VariableInfoProfile extends CommonInfoProfile {
+trait VariableInfoProfile extends CreateInfoProfile with CommonInfoProfile {
   /**
    * Returns the JDI representation this profile instance wraps.
    *
@@ -37,7 +37,7 @@ trait VariableInfoProfile extends CommonInfoProfile {
    */
   def typeInfo: TypeInfoProfile
 
-  /**
+  /**rsenkbeil3
    * Returns the type information for the variable.
    *
    * @return Success containing the profile containing type information,
@@ -85,33 +85,53 @@ trait VariableInfoProfile extends CommonInfoProfile {
    * Sets the primitive value of this variable.
    *
    * @param value The new value for the variable
-   * @return Success containing the value, otherwise a failure
+   * @return Success containing the new remote value, otherwise a failure
    */
-  def trySetValue(value: AnyVal): Try[AnyVal] = Try(setValue(value))
+  def trySetValue(value: AnyVal): Try[ValueInfoProfile] = Try(setValue(value))
 
   /**
    * Sets the primitive value of this variable.
    *
    * @param value The new value for the variable
-   * @return The new value
+   * @return The new remote value
    */
-  def setValue(value: AnyVal): AnyVal
+  def setValue(value: AnyVal): ValueInfoProfile =
+    setValueFromInfo(createRemotely(value))
 
   /**
    * Sets the string value of this variable.
    *
    * @param value The new value for the variable
-   * @return Success containing the value, otherwise a failure
+   * @return Success containing the new remote value, otherwise a failure
    */
-  def trySetValue(value: String): Try[String] = Try(setValue(value))
+  def trySetValue(value: String): Try[ValueInfoProfile] = Try(setValue(value))
 
   /**
    * Sets the string value of this variable.
    *
    * @param value The new value for the variable
-   * @return The new value
+   * @return The new remote value
    */
-  def setValue(value: String): String
+  def setValue(value: String): ValueInfoProfile = {
+    setValueFromInfo(createRemotely(value))
+  }
+
+  /**
+   * Sets the value of this variable using info about another remote value.
+   *
+   * @param valueInfo The remote value to set for the variable
+   * @return Success containing the variable's value info, otherwise a failure
+   */
+  def trySetValueFromInfo(valueInfo: ValueInfoProfile): Try[ValueInfoProfile] =
+    Try(setValueFromInfo(valueInfo))
+
+  /**
+   * Sets the value of this variable using info about another remote value.
+   *
+   * @param valueInfo The remote value to set for the variable
+   * @return The info for the variable's new value
+   */
+  def setValueFromInfo(valueInfo: ValueInfoProfile): ValueInfoProfile
 
   /**
    * Returns a string presenting a better human-readable description of

--- a/scala-debugger-api/src/test/scala/org/scaladebugger/api/profiles/pure/info/PureCreateInfoProfileSpec.scala
+++ b/scala-debugger-api/src/test/scala/org/scaladebugger/api/profiles/pure/info/PureCreateInfoProfileSpec.scala
@@ -1,0 +1,168 @@
+package org.scaladebugger.api.profiles.pure.info
+
+import com.sun.jdi._
+import org.scaladebugger.api.lowlevel.classes.ClassManager
+import org.scaladebugger.api.profiles.traits.info.{ReferenceTypeInfoProfile, ValueInfoProfile}
+import org.scaladebugger.api.virtualmachines.ScalaVirtualMachine
+import org.scalamock.scalatest.MockFactory
+import org.scalatest.{FunSpec, Matchers, ParallelTestExecution}
+import test.JDIMockHelpers
+
+import scala.util.{Failure, Success}
+
+class PureCreateInfoProfileSpec extends FunSpec with Matchers
+  with ParallelTestExecution with MockFactory with JDIMockHelpers
+{
+  private val mockScalaVirtualMachine = mock[ScalaVirtualMachine]
+  private val mockVirtualMachine = mock[VirtualMachine]
+  private val mockCreateNewValueProfile = mockFunction[Value, ValueInfoProfile]
+
+  private val pureCreateInfoProfile = new Object with PureCreateInfoProfile {
+    override protected def createNewValueProfile(value: Value): ValueInfoProfile =
+      mockCreateNewValueProfile(value)
+
+    override protected val scalaVirtualMachine: ScalaVirtualMachine = mockScalaVirtualMachine
+    override protected val _virtualMachine: VirtualMachine = mockVirtualMachine
+  }
+
+  describe("PureCreateInfoProfile") {
+    describe("#createRemotely(AnyVal)") {
+      it("should create and wrap a mirrored boolean value in a value info profile") {
+        val expected = mock[ValueInfoProfile]
+        val testValue: Boolean = true
+
+        val mockValue = mock[BooleanValue]
+        (mockVirtualMachine.mirrorOf(_: Boolean)).expects(testValue)
+          .returning(mockValue).once()
+
+        mockCreateNewValueProfile.expects(mockValue).returning(expected).once()
+
+        val actual = pureCreateInfoProfile.createRemotely(testValue)
+
+        actual should be (expected)
+      }
+
+      it("should create and wrap a mirrored byte value in a value info profile") {
+        val expected = mock[ValueInfoProfile]
+        val testValue: Byte = 33
+
+        val mockValue = mock[ByteValue]
+        (mockVirtualMachine.mirrorOf(_: Byte)).expects(testValue)
+          .returning(mockValue).once()
+
+        mockCreateNewValueProfile.expects(mockValue).returning(expected).once()
+
+        val actual = pureCreateInfoProfile.createRemotely(testValue)
+
+        actual should be (expected)
+      }
+
+      it("should create and wrap a mirrored char value in a value info profile") {
+        val expected = mock[ValueInfoProfile]
+        val testValue: Char = 33
+
+        val mockValue = mock[CharValue]
+        (mockVirtualMachine.mirrorOf(_: Char)).expects(testValue)
+          .returning(mockValue).once()
+
+        mockCreateNewValueProfile.expects(mockValue).returning(expected).once()
+
+        val actual = pureCreateInfoProfile.createRemotely(testValue)
+
+        actual should be (expected)
+      }
+
+      it("should create and wrap a mirrored integer value in a value info profile") {
+        val expected = mock[ValueInfoProfile]
+        val testValue: Int = 33
+
+        val mockValue = mock[IntegerValue]
+        (mockVirtualMachine.mirrorOf(_: Int)).expects(testValue)
+          .returning(mockValue).once()
+
+        mockCreateNewValueProfile.expects(mockValue).returning(expected).once()
+
+        val actual = pureCreateInfoProfile.createRemotely(testValue)
+
+        actual should be (expected)
+      }
+
+      it("should create and wrap a mirrored short value in a value info profile") {
+        val expected = mock[ValueInfoProfile]
+        val testValue: Short = 33
+
+        val mockValue = mock[ShortValue]
+        (mockVirtualMachine.mirrorOf(_: Short)).expects(testValue)
+          .returning(mockValue).once()
+
+        mockCreateNewValueProfile.expects(mockValue).returning(expected).once()
+
+        val actual = pureCreateInfoProfile.createRemotely(testValue)
+
+        actual should be (expected)
+      }
+
+      it("should create and wrap a mirrored long value in a value info profile") {
+        val expected = mock[ValueInfoProfile]
+        val testValue: Long = 33
+
+        val mockValue = mock[LongValue]
+        (mockVirtualMachine.mirrorOf(_: Long)).expects(testValue)
+          .returning(mockValue).once()
+
+        mockCreateNewValueProfile.expects(mockValue).returning(expected).once()
+
+        val actual = pureCreateInfoProfile.createRemotely(testValue)
+
+        actual should be (expected)
+      }
+
+      it("should create and wrap a mirrored float value in a value info profile") {
+        val expected = mock[ValueInfoProfile]
+        val testValue: Float = 33
+
+        val mockValue = mock[FloatValue]
+        (mockVirtualMachine.mirrorOf(_: Float)).expects(testValue)
+          .returning(mockValue).once()
+
+        mockCreateNewValueProfile.expects(mockValue).returning(expected).once()
+
+        val actual = pureCreateInfoProfile.createRemotely(testValue)
+
+        actual should be (expected)
+      }
+
+      it("should create and wrap a mirrored double value in a value info profile") {
+        val expected = mock[ValueInfoProfile]
+        val testValue: Double = 33
+
+        val mockValue = mock[DoubleValue]
+        (mockVirtualMachine.mirrorOf(_: Double)).expects(testValue)
+          .returning(mockValue).once()
+
+        mockCreateNewValueProfile.expects(mockValue).returning(expected).once()
+
+        val actual = pureCreateInfoProfile.createRemotely(testValue)
+
+        actual should be (expected)
+      }
+    }
+
+    describe("#createRemotely(String)") {
+      it("should create and wrap a mirrored string value in a value info profile") {
+        val expected = mock[ValueInfoProfile]
+        val testString = "some string"
+
+        val mockValue = mock[StringReference]
+        (mockVirtualMachine.mirrorOf(_: String)).expects(testString)
+          .returning(mockValue).once()
+
+        mockCreateNewValueProfile.expects(mockValue).returning(expected).once()
+
+        val actual = pureCreateInfoProfile.createRemotely(testString)
+
+        actual should be (expected)
+      }
+    }
+  }
+}

--- a/scala-debugger-api/src/test/scala/org/scaladebugger/api/profiles/pure/info/PureLocalVariableInfoProfileSpec.scala
+++ b/scala-debugger-api/src/test/scala/org/scaladebugger/api/profiles/pure/info/PureLocalVariableInfoProfileSpec.scala
@@ -5,6 +5,7 @@ import org.scaladebugger.api.profiles.traits.info.{FrameInfoProfile, TypeInfoPro
 import org.scaladebugger.api.virtualmachines.ScalaVirtualMachine
 import org.scalamock.scalatest.MockFactory
 import org.scalatest.{FunSpec, Matchers, ParallelTestExecution}
+import test.InfoTestClasses.TestMiscInfoProfileTrait
 
 class PureLocalVariableInfoProfileSpec extends FunSpec with Matchers
   with ParallelTestExecution with MockFactory
@@ -118,47 +119,27 @@ class PureLocalVariableInfoProfileSpec extends FunSpec with Matchers
       }
     }
 
-    describe("#trySetValue") {
-      it("should set strings directly on the object") {
-        val expected = "some value"
 
-        // Mirror the local string remotely
-        val mockStringReference = mock[StringReference]
-        (mockVirtualMachine.mirrorOf(_: String)).expects(expected)
-          .returning(mockStringReference).once()
+    describe("#setValueFromInfo") {
+      it("should be able to set the value using the info") {
+        val expected = mock[ValueInfoProfile]
 
-        // Retrieve the underlying stack frame
+        // Retrieves JDI stack frame to set value
         val mockStackFrame = mock[StackFrame]
         (mockFrameInfoProfile.toJdiInstance _).expects()
           .returning(mockStackFrame).once()
 
-        // Ensure setting value on stack frame is verified
+        // Retrieves JDI value from info
+        val mockStringReference = mock[StringReference]
+        (expected.toJdiInstance _).expects()
+          .returning(mockStringReference).once()
+
+        // Ensure setting the value on the stack frame is verified
         (mockStackFrame.setValue _)
           .expects(mockLocalVariable, mockStringReference)
           .once()
 
-        pureLocalVariableInfoProfile.trySetValue(expected).get should be (expected)
-      }
-
-      it("should set primitive values directly on the object") {
-        val expected = 3.toByte
-
-        // Mirror the local string remotely
-        val mockByteValue = mock[ByteValue]
-        (mockVirtualMachine.mirrorOf(_: Byte)).expects(expected)
-          .returning(mockByteValue).once()
-
-        // Retrieve the underlying stack frame
-        val mockStackFrame = mock[StackFrame]
-        (mockFrameInfoProfile.toJdiInstance _).expects()
-          .returning(mockStackFrame).once()
-
-        // Ensure setting value on stack frame is verified
-        (mockStackFrame.setValue _)
-          .expects(mockLocalVariable, mockByteValue)
-          .once()
-
-        pureLocalVariableInfoProfile.trySetValue(expected).get should be (expected)
+        pureLocalVariableInfoProfile.setValueFromInfo(expected) should be (expected)
       }
     }
 

--- a/scala-debugger-api/src/test/scala/org/scaladebugger/api/profiles/pure/info/PureMiscInfoProfileSpec.scala
+++ b/scala-debugger-api/src/test/scala/org/scaladebugger/api/profiles/pure/info/PureMiscInfoProfileSpec.scala
@@ -17,7 +17,6 @@ class PureMiscInfoProfileSpec extends FunSpec with Matchers
   private val mockVirtualMachine = mock[VirtualMachine]
   private val mockClassManager = mock[ClassManager]
 
-  private val mockMiscNewValueProfile = mockFunction[Value, ValueInfoProfile]
   private val mockRetrieveCommandLineArguments = mockFunction[Seq[String]]
   private val mockRetrieveMainClassName = mockFunction[String]
   private val mockMiscNewReferenceTypeProfile = mockFunction[ReferenceType, ReferenceTypeInfoProfile]
@@ -30,11 +29,6 @@ class PureMiscInfoProfileSpec extends FunSpec with Matchers
     override protected def miscNewReferenceTypeProfile(
       referenceType: ReferenceType
     ): ReferenceTypeInfoProfile = mockMiscNewReferenceTypeProfile(referenceType)
-
-
-    override protected def miscNewValueProfile(value: Value): ValueInfoProfile =
-      mockMiscNewValueProfile(value)
-
     override protected val classManager: ClassManager = mockClassManager
     override protected val scalaVirtualMachine: ScalaVirtualMachine = mockScalaVirtualMachine
     override protected val _virtualMachine: VirtualMachine = mockVirtualMachine
@@ -68,146 +62,6 @@ class PureMiscInfoProfileSpec extends FunSpec with Matchers
         actual should be (expected)
       }
     }
-
-    describe("#createRemotely(AnyVal)") {
-      it("should create and wrap a mirrored boolean value in a value info profile") {
-        val expected = mock[ValueInfoProfile]
-        val testValue: Boolean = true
-
-        val mockValue = mock[BooleanValue]
-        (mockVirtualMachine.mirrorOf(_: Boolean)).expects(testValue)
-          .returning(mockValue).once()
-
-        mockMiscNewValueProfile.expects(mockValue).returning(expected).once()
-
-        val actual = pureMiscInfoProfile.createRemotely(testValue)
-
-        actual should be (expected)
-      }
-
-      it("should create and wrap a mirrored byte value in a value info profile") {
-        val expected = mock[ValueInfoProfile]
-        val testValue: Byte = 33
-
-        val mockValue = mock[ByteValue]
-        (mockVirtualMachine.mirrorOf(_: Byte)).expects(testValue)
-          .returning(mockValue).once()
-
-        mockMiscNewValueProfile.expects(mockValue).returning(expected).once()
-
-        val actual = pureMiscInfoProfile.createRemotely(testValue)
-
-        actual should be (expected)
-      }
-
-      it("should create and wrap a mirrored char value in a value info profile") {
-        val expected = mock[ValueInfoProfile]
-        val testValue: Char = 33
-
-        val mockValue = mock[CharValue]
-        (mockVirtualMachine.mirrorOf(_: Char)).expects(testValue)
-          .returning(mockValue).once()
-
-        mockMiscNewValueProfile.expects(mockValue).returning(expected).once()
-
-        val actual = pureMiscInfoProfile.createRemotely(testValue)
-
-        actual should be (expected)
-      }
-
-      it("should create and wrap a mirrored integer value in a value info profile") {
-        val expected = mock[ValueInfoProfile]
-        val testValue: Int = 33
-
-        val mockValue = mock[IntegerValue]
-        (mockVirtualMachine.mirrorOf(_: Int)).expects(testValue)
-          .returning(mockValue).once()
-
-        mockMiscNewValueProfile.expects(mockValue).returning(expected).once()
-
-        val actual = pureMiscInfoProfile.createRemotely(testValue)
-
-        actual should be (expected)
-      }
-
-      it("should create and wrap a mirrored short value in a value info profile") {
-        val expected = mock[ValueInfoProfile]
-        val testValue: Short = 33
-
-        val mockValue = mock[ShortValue]
-        (mockVirtualMachine.mirrorOf(_: Short)).expects(testValue)
-          .returning(mockValue).once()
-
-        mockMiscNewValueProfile.expects(mockValue).returning(expected).once()
-
-        val actual = pureMiscInfoProfile.createRemotely(testValue)
-
-        actual should be (expected)
-      }
-
-      it("should create and wrap a mirrored long value in a value info profile") {
-        val expected = mock[ValueInfoProfile]
-        val testValue: Long = 33
-
-        val mockValue = mock[LongValue]
-        (mockVirtualMachine.mirrorOf(_: Long)).expects(testValue)
-          .returning(mockValue).once()
-
-        mockMiscNewValueProfile.expects(mockValue).returning(expected).once()
-
-        val actual = pureMiscInfoProfile.createRemotely(testValue)
-
-        actual should be (expected)
-      }
-
-      it("should create and wrap a mirrored float value in a value info profile") {
-        val expected = mock[ValueInfoProfile]
-        val testValue: Float = 33
-
-        val mockValue = mock[FloatValue]
-        (mockVirtualMachine.mirrorOf(_: Float)).expects(testValue)
-          .returning(mockValue).once()
-
-        mockMiscNewValueProfile.expects(mockValue).returning(expected).once()
-
-        val actual = pureMiscInfoProfile.createRemotely(testValue)
-
-        actual should be (expected)
-      }
-
-      it("should create and wrap a mirrored double value in a value info profile") {
-        val expected = mock[ValueInfoProfile]
-        val testValue: Double = 33
-
-        val mockValue = mock[DoubleValue]
-        (mockVirtualMachine.mirrorOf(_: Double)).expects(testValue)
-          .returning(mockValue).once()
-
-        mockMiscNewValueProfile.expects(mockValue).returning(expected).once()
-
-        val actual = pureMiscInfoProfile.createRemotely(testValue)
-
-        actual should be (expected)
-      }
-    }
-
-    describe("#createRemotely(String)") {
-      it("should create and wrap a mirrored string value in a value info profile") {
-        val expected = mock[ValueInfoProfile]
-        val testString = "some string"
-
-        val mockValue = mock[StringReference]
-        (mockVirtualMachine.mirrorOf(_: String)).expects(testString)
-          .returning(mockValue).once()
-
-        mockMiscNewValueProfile.expects(mockValue).returning(expected).once()
-
-        val actual = pureMiscInfoProfile.createRemotely(testString)
-
-        actual should be (expected)
-      }
-    }
-
     describe("#sourceNameToPaths") {
       it("should ignore any class with absent source name information") {
         val expected = Nil

--- a/scala-debugger-api/src/test/scala/org/scaladebugger/api/profiles/swappable/info/SwappableCreateInfoProfileSpec.scala
+++ b/scala-debugger-api/src/test/scala/org/scaladebugger/api/profiles/swappable/info/SwappableCreateInfoProfileSpec.scala
@@ -1,0 +1,75 @@
+package org.scaladebugger.api.profiles.swappable.info
+
+import org.scaladebugger.api.profiles.ProfileManager
+import org.scaladebugger.api.profiles.swappable.SwappableDebugProfile
+import org.scaladebugger.api.profiles.traits.DebugProfile
+import org.scaladebugger.api.profiles.traits.info.ValueInfoProfile
+import org.scalamock.scalatest.MockFactory
+import org.scalatest.{FunSpec, Matchers, ParallelTestExecution}
+
+class SwappableCreateInfoProfileSpec extends FunSpec with Matchers
+  with ParallelTestExecution with MockFactory
+{
+  private val mockDebugProfile = mock[DebugProfile]
+  private val mockProfileManager = mock[ProfileManager]
+
+  private val swappableDebugProfile = new Object with SwappableDebugProfile {
+    override protected val profileManager: ProfileManager = mockProfileManager
+  }
+
+  describe("SwappableMiscInfoProfile") {
+    describe("#createRemotely(AnyVal)") {
+      it("should invoke the method on the underlying profile") {
+        val expected = mock[ValueInfoProfile]
+        val value: AnyVal = 33
+
+        (mockProfileManager.retrieve _).expects(*)
+          .returning(Some(mockDebugProfile)).once()
+
+        (mockDebugProfile.createRemotely(_: AnyVal)).expects(value)
+          .returning(expected).once()
+
+        val actual = swappableDebugProfile.createRemotely(value)
+
+        actual should be (expected)
+      }
+
+      it("should throw an exception if there is no underlying profile") {
+        val value = "some string"
+
+        (mockProfileManager.retrieve _).expects(*).returning(None).once()
+
+        intercept[AssertionError] {
+          swappableDebugProfile.createRemotely(value)
+        }
+      }
+    }
+
+    describe("#createRemotely(String)") {
+      it("should invoke the method on the underlying profile") {
+        val expected = mock[ValueInfoProfile]
+        val value = "some string"
+
+        (mockProfileManager.retrieve _).expects(*)
+          .returning(Some(mockDebugProfile)).once()
+
+        (mockDebugProfile.createRemotely(_: String)).expects(value)
+          .returning(expected).once()
+
+        val actual = swappableDebugProfile.createRemotely(value)
+
+        actual should be (expected)
+      }
+
+      it("should throw an exception if there is no underlying profile") {
+        val value = "some string"
+
+        (mockProfileManager.retrieve _).expects(*).returning(None).once()
+
+        intercept[AssertionError] {
+          swappableDebugProfile.createRemotely(value)
+        }
+      }
+    }
+  }
+}

--- a/scala-debugger-api/src/test/scala/org/scaladebugger/api/profiles/traits/info/ArrayInfoProfileSpec.scala
+++ b/scala-debugger-api/src/test/scala/org/scaladebugger/api/profiles/traits/info/ArrayInfoProfileSpec.scala
@@ -146,35 +146,113 @@ class ArrayInfoProfileSpec extends FunSpec with Matchers
       }
     }
 
+    describe("#trySetValueFromInfo") {
+      it("should wrap the unsafe call in a Try") {
+        val mockUnsafeMethod = mockFunction[Int, ValueInfoProfile, ValueInfoProfile]
+
+        val variableInfoProfile = new TestArrayInfoProfile {
+          override def setValueFromInfo(
+            index: Int, valueInfo: ValueInfoProfile
+          ): ValueInfoProfile = mockUnsafeMethod(index, valueInfo)
+        }
+
+        val a1 = 999
+        val a2 = mock[ValueInfoProfile]
+        val r = mock[ValueInfoProfile]
+        mockUnsafeMethod.expects(a1, a2).returning(r).once()
+        variableInfoProfile.trySetValueFromInfo(a1, a2).get should be (r)
+      }
+    }
+
     describe("#trySetValue") {
       it("should wrap the unsafe call in a Try") {
-        val mockUnsafeMethod = mockFunction[Int, Any, Any]
+        val mockUnsafeMethod = mockFunction[Int, Any, ValueInfoProfile]
 
         val arrayInfoProfile = new TestArrayInfoProfile {
-          override def setValue(index: Int, value: Any): Any =
+          override def setValue[T](
+            index: Int,
+            value: T
+          )(implicit typeTag: scala.reflect.runtime.universe.TypeTag[T]): ValueInfoProfile =
             mockUnsafeMethod(index, value)
         }
 
         val a1 = 999
         val a2 = "value"
-        val r = a2
+        val r = mock[ValueInfoProfile]
         mockUnsafeMethod.expects(a1, a2).returning(r).once()
         arrayInfoProfile.trySetValue(a1, a2).get should be (r)
       }
     }
 
+    describe("#setValue") {
+      it("should throw an exception if the value is not an AnyVal or String") {
+        val arrayInfoProfile = new TestArrayInfoProfile
+
+        intercept[UnsupportedTypeException] {
+          arrayInfoProfile.setValue(0, new AnyRef)
+        }
+      }
+
+      it("should convert the AnyVal value to a remote value and set it") {
+        val mockCreateRemotely = mockFunction[AnyVal, ValueInfoProfile]
+        val mockSetValueFromInfo = mockFunction[Int, ValueInfoProfile, ValueInfoProfile]
+        val arrayInfoProfile = new TestArrayInfoProfile {
+          override def createRemotely(value: AnyVal): ValueInfoProfile =
+            mockCreateRemotely(value)
+
+          override def setValueFromInfo(
+            index: Int,
+            value: ValueInfoProfile
+          ): ValueInfoProfile = mockSetValueFromInfo(index, value)
+        }
+
+        val a1 = 999
+        val a2: AnyVal = 33
+        val r = mock[ValueInfoProfile]
+        mockCreateRemotely.expects(a2).returning(r).once()
+        mockSetValueFromInfo.expects(a1, r).returning(r).once()
+
+        arrayInfoProfile.setValue(a1, a2) should be (r)
+      }
+
+      it("should convert the String value to a remote value and set it") {
+        val mockCreateRemotely = mockFunction[String, ValueInfoProfile]
+        val mockSetValueFromInfo = mockFunction[Int, ValueInfoProfile, ValueInfoProfile]
+        val arrayInfoProfile = new TestArrayInfoProfile {
+          override def createRemotely(value: String): ValueInfoProfile =
+            mockCreateRemotely(value)
+
+          override def setValueFromInfo(
+            index: Int,
+            value: ValueInfoProfile
+          ): ValueInfoProfile = mockSetValueFromInfo(index, value)
+        }
+
+        val a1 = 999
+        val a2 = "some string"
+        val r = mock[ValueInfoProfile]
+        mockCreateRemotely.expects(a2).returning(r).once()
+        mockSetValueFromInfo.expects(a1, r).returning(r).once()
+
+        arrayInfoProfile.setValue(a1, a2) should be (r)
+      }
+    }
+
     describe("#update") {
       it("should invoke the unsafe setValue method") {
-        val mockUnsafeMethod = mockFunction[Int, Any, Any]
+        val mockUnsafeMethod = mockFunction[Int, Any, ValueInfoProfile]
 
         val arrayInfoProfile = new TestArrayInfoProfile {
-          override def setValue(index: Int, value: Any): Any =
+          override def setValue[T](
+            index: Int,
+            value: T
+          )(implicit typeTag: scala.reflect.runtime.universe.TypeTag[T]): ValueInfoProfile =
             mockUnsafeMethod(index, value)
         }
 
         val a1 = 999
         val a2 = "value"
-        val r = a2
+        val r = mock[ValueInfoProfile]
         mockUnsafeMethod.expects(a1, a2).returning(r).once()
         (arrayInfoProfile(a1) = a2) should be (r)
       }
@@ -211,41 +289,213 @@ class ArrayInfoProfileSpec extends FunSpec with Matchers
       }
     }
 
+    describe("#trySetValuesFromInfo(index, values, srcIndex, totalElements)") {
+      it("should wrap the unsafe call in a Try") {
+        val mockUnsafeMethod = mockFunction[Int, Seq[ValueInfoProfile], Int, Int, Seq[ValueInfoProfile]]
+
+        val variableInfoProfile = new TestArrayInfoProfile {
+          override def setValuesFromInfo(
+            index: Int, values: Seq[ValueInfoProfile],
+            srcIndex: Int, totalElements: Int
+          ): Seq[ValueInfoProfile] = mockUnsafeMethod(index, values, srcIndex, totalElements)
+        }
+
+        val a1 = 999
+        val a2 = Seq(mock[ValueInfoProfile])
+        val a3 = 1
+        val a4 = 2
+        val r = a2
+        mockUnsafeMethod.expects(a1, a2, a3, a4).returning(r).once()
+        variableInfoProfile.trySetValuesFromInfo(a1, a2, a3, a4).get should be (r)
+      }
+    }
+
     describe("#trySetValues(index, values, srcIndex, totalElements)") {
       it("should wrap the unsafe call in a Try") {
-        val mockUnsafeMethod = mockFunction[Int, Seq[Any], Int, Int, Seq[Any]]
+        val mockUnsafeMethod = mockFunction[Int, Seq[Any], Int, Int, Seq[ValueInfoProfile]]
 
         val arrayInfoProfile = new TestArrayInfoProfile {
-          override def setValues(
+          override def setValues[T](
             index: Int,
-            values: Seq[Any],
+            values: Seq[T],
             srcIndex: Int,
             totalElements: Int
-          ): Seq[Any] = mockUnsafeMethod(index, values, srcIndex, totalElements)
+          )(implicit typeTag: scala.reflect.runtime.universe.TypeTag[T]): Seq[ValueInfoProfile] =
+            mockUnsafeMethod(index, values, srcIndex, totalElements)
         }
 
         val a1 = 999
         val a2 = Seq(1, 2, "test")
         val a3 = 40
         val a4 = 55
-        val r = a2
+        val r = Seq(mock[ValueInfoProfile])
         mockUnsafeMethod.expects(a1, a2, a3, a4).returning(r).once()
         arrayInfoProfile.trySetValues(a1, a2, a3, a4).get should be (r)
       }
     }
 
+    describe("#setValues(index, values, srcIndex, totalElements)") {
+      it("should throw an exception if a value is not an AnyVal or String") {
+        val arrayInfoProfile = new TestArrayInfoProfile
+
+        intercept[UnsupportedTypeException] {
+          arrayInfoProfile.setValues(0, Seq(new AnyRef), 0, 1)
+        }
+      }
+
+      it("should convert the local AnyVal values to a remote values and set them") {
+        val mockCreateRemotely = mockFunction[AnyVal, ValueInfoProfile]
+        val mockSetValuesFromInfo =
+          mockFunction[Int, Seq[ValueInfoProfile], Int, Int, Seq[ValueInfoProfile]]
+        val arrayInfoProfile = new TestArrayInfoProfile {
+          override def createRemotely(value: AnyVal): ValueInfoProfile =
+            mockCreateRemotely(value)
+
+          override def setValuesFromInfo(
+            index: Int,
+            values: Seq[ValueInfoProfile],
+            srcIndex: Int,
+            totalElements: Int
+          ): Seq[ValueInfoProfile] = mockSetValuesFromInfo(
+            index, values, srcIndex, totalElements
+          )
+        }
+
+        val a1 = 999
+        val a2: Seq[AnyVal] = Seq(3, true)
+        val a3 = 1
+        val a4 = 2
+        val r = a2.map(_ => mock[ValueInfoProfile])
+
+        r.zip(a2).foreach { case (r, a) =>
+          mockCreateRemotely.expects(a).returning(r).once()
+        }
+        mockSetValuesFromInfo.expects(a1, r, a3, a4).returning(r).once()
+
+        arrayInfoProfile.setValues(a1, a2, a3, a4) should be (r)
+      }
+
+      it("should convert the local String values to a remote values and set them") {
+        val mockCreateRemotely = mockFunction[String, ValueInfoProfile]
+        val mockSetValuesFromInfo =
+          mockFunction[Int, Seq[ValueInfoProfile], Int, Int, Seq[ValueInfoProfile]]
+        val arrayInfoProfile = new TestArrayInfoProfile {
+          override def createRemotely(value: String): ValueInfoProfile =
+            mockCreateRemotely(value)
+
+          override def setValuesFromInfo(
+            index: Int,
+            values: Seq[ValueInfoProfile],
+            srcIndex: Int,
+            totalElements: Int
+          ): Seq[ValueInfoProfile] = mockSetValuesFromInfo(
+            index, values, srcIndex, totalElements
+          )
+        }
+
+        val a1 = 999
+        val a2: Seq[String] = Seq("one", "two")
+        val a3 = 1
+        val a4 = 2
+        val r = a2.map(_ => mock[ValueInfoProfile])
+
+        r.zip(a2).foreach { case (r, a) =>
+          mockCreateRemotely.expects(a).returning(r).once()
+        }
+        mockSetValuesFromInfo.expects(a1, r, a3, a4).returning(r).once()
+
+        arrayInfoProfile.setValues(a1, a2, a3, a4) should be (r)
+      }
+    }
+
+    describe("#trySetValuesFromInfo(values)") {
+      it("should wrap the unsafe call in a Try") {
+        val mockUnsafeMethod = mockFunction[Seq[ValueInfoProfile], Seq[ValueInfoProfile]]
+
+        val variableInfoProfile = new TestArrayInfoProfile {
+          override def setValuesFromInfo(
+            values: Seq[ValueInfoProfile]
+          ): Seq[ValueInfoProfile] = mockUnsafeMethod(values)
+        }
+
+        val a1 = Seq(mock[ValueInfoProfile])
+        val r = a1
+        mockUnsafeMethod.expects(a1).returning(r).once()
+        variableInfoProfile.trySetValuesFromInfo(a1).get should be (r)
+      }
+    }
+
     describe("#trySetValues(values)") {
       it("should wrap the unsafe call in a Try") {
-        val mockUnsafeMethod = mockFunction[Seq[Any], Seq[Any]]
+        val mockUnsafeMethod = mockFunction[Seq[Any], Seq[ValueInfoProfile]]
 
         val arrayInfoProfile = new TestArrayInfoProfile {
-          override def setValues(values: Seq[Any]): Seq[Any] = mockUnsafeMethod(values)
+          override def setValues[T](
+            values: Seq[T]
+          )(implicit typeTag: scala.reflect.runtime.universe.TypeTag[T]): Seq[ValueInfoProfile] =
+            mockUnsafeMethod(values)
         }
 
         val a1 = Seq(1, 2, "test")
-        val r = a1
+        val r = Seq(mock[ValueInfoProfile])
         mockUnsafeMethod.expects(a1).returning(r).once()
         arrayInfoProfile.trySetValues(a1).get should be (r)
+      }
+    }
+
+    describe("#setValues(values)") {
+      it("should throw an exception if a value is not an AnyVal or String") {
+        val arrayInfoProfile = new TestArrayInfoProfile
+
+        intercept[UnsupportedTypeException] {
+          arrayInfoProfile.setValues(Seq(new AnyRef))
+        }
+      }
+
+      it("should convert the local AnyVal values to a remote values and set them") {
+        val mockCreateRemotely = mockFunction[AnyVal, ValueInfoProfile]
+        val mockSetValuesFromInfo = mockFunction[Seq[ValueInfoProfile], Seq[ValueInfoProfile]]
+        val arrayInfoProfile = new TestArrayInfoProfile {
+          override def createRemotely(value: AnyVal): ValueInfoProfile =
+            mockCreateRemotely(value)
+
+          override def setValuesFromInfo(
+            values: Seq[ValueInfoProfile]
+          ): Seq[ValueInfoProfile] = mockSetValuesFromInfo(values)
+        }
+
+        val a1: Seq[AnyVal] = Seq(3, true)
+        val r = a1.map(_ => mock[ValueInfoProfile])
+
+        r.zip(a1).foreach { case (r, a) =>
+          mockCreateRemotely.expects(a).returning(r).once()
+        }
+        mockSetValuesFromInfo.expects(r).returning(r).once()
+
+        arrayInfoProfile.setValues(a1) should be (r)
+      }
+
+      it("should convert the local String values to a remote values and set them") {
+        val mockCreateRemotely = mockFunction[String, ValueInfoProfile]
+        val mockSetValuesFromInfo = mockFunction[Seq[ValueInfoProfile], Seq[ValueInfoProfile]]
+        val arrayInfoProfile = new TestArrayInfoProfile {
+          override def createRemotely(value: String): ValueInfoProfile =
+            mockCreateRemotely(value)
+
+          override def setValuesFromInfo(
+            values: Seq[ValueInfoProfile]
+          ): Seq[ValueInfoProfile] = mockSetValuesFromInfo(values)
+        }
+
+        val a1 = Seq("one", "two")
+        val r = a1.map(_ => mock[ValueInfoProfile])
+
+        r.zip(a1).foreach { case (r, a) =>
+          mockCreateRemotely.expects(a).returning(r).once()
+        }
+        mockSetValuesFromInfo.expects(r).returning(r).once()
+
+        arrayInfoProfile.setValues(a1) should be (r)
       }
     }
   }

--- a/scala-debugger-api/src/test/scala/org/scaladebugger/api/profiles/traits/info/VariableInfoProfileSpec.scala
+++ b/scala-debugger-api/src/test/scala/org/scaladebugger/api/profiles/traits/info/VariableInfoProfileSpec.scala
@@ -10,6 +10,96 @@ class VariableInfoProfileSpec extends FunSpec with Matchers
   with ParallelTestExecution with MockFactory
 {
   describe("VariableInfoProfile") {
+    describe("#trySetValue(AnyVal)") {
+      it("should wrap the unsafe call in a Try") {
+        val mockUnsafeMethod = mockFunction[AnyVal, ValueInfoProfile]
+
+        val variableInfoProfile = new TestVariableInfoProfile {
+          override def setValue(value: AnyVal): ValueInfoProfile =
+            mockUnsafeMethod(value)
+        }
+
+        val a1: AnyVal = 333
+        val r = mock[ValueInfoProfile]
+        mockUnsafeMethod.expects(a1).returning(r).once()
+        variableInfoProfile.trySetValue(a1).get should be (r)
+      }
+    }
+
+    describe("#setValue(AnyVal)") {
+      it("should convert the local value to a remote value and set it") {
+        val mockCreateRemotely = mockFunction[AnyVal, ValueInfoProfile]
+        val mockSetValueFromInfo = mockFunction[ValueInfoProfile, ValueInfoProfile]
+        val variableInfoProfile = new TestVariableInfoProfile {
+          override def createRemotely(value: AnyVal): ValueInfoProfile =
+            mockCreateRemotely(value)
+
+          override def setValueFromInfo(
+            valueInfo: ValueInfoProfile
+          ): ValueInfoProfile = mockSetValueFromInfo(valueInfo)
+        }
+
+        val a1: AnyVal = 33
+        val r = mock[ValueInfoProfile]
+        mockCreateRemotely.expects(a1).returning(r).once()
+        mockSetValueFromInfo.expects(r).returning(r).once()
+        variableInfoProfile.setValue(a1) should be (r)
+      }    }
+
+    describe("#trySetValue(String)") {
+      it("should wrap the unsafe call in a Try") {
+        val mockUnsafeMethod = mockFunction[String, ValueInfoProfile]
+
+        val variableInfoProfile = new TestVariableInfoProfile {
+          override def setValue(value: String): ValueInfoProfile =
+            mockUnsafeMethod(value)
+        }
+
+        val a1 = "some string"
+        val r = mock[ValueInfoProfile]
+        mockUnsafeMethod.expects(a1).returning(r).once()
+        variableInfoProfile.trySetValue(a1).get should be (r)
+      }
+    }
+
+    describe("#setValue(String)") {
+      it("should convert the local value to a remote value and set it") {
+        val mockCreateRemotely = mockFunction[String, ValueInfoProfile]
+        val mockSetValueFromInfo = mockFunction[ValueInfoProfile, ValueInfoProfile]
+        val variableInfoProfile = new TestVariableInfoProfile {
+          override def createRemotely(value: String): ValueInfoProfile =
+            mockCreateRemotely(value)
+
+          override def setValueFromInfo(
+            valueInfo: ValueInfoProfile
+          ): ValueInfoProfile = mockSetValueFromInfo(valueInfo)
+        }
+
+        val a1 = "some string"
+        val r = mock[ValueInfoProfile]
+        mockCreateRemotely.expects(a1).returning(r).once()
+        mockSetValueFromInfo.expects(r).returning(r).once()
+        variableInfoProfile.setValue(a1) should be (r)
+      }
+    }
+
+    describe("#trySetValueFromInfo") {
+      it("should wrap the unsafe call in a Try") {
+        val mockUnsafeMethod = mockFunction[ValueInfoProfile, ValueInfoProfile]
+
+        val variableInfoProfile = new TestVariableInfoProfile {
+          override def setValueFromInfo(
+            valueInfo: ValueInfoProfile
+          ): ValueInfoProfile = mockUnsafeMethod(valueInfo)
+        }
+
+        val a1 = mock[ValueInfoProfile]
+        val r = mock[ValueInfoProfile]
+        mockUnsafeMethod.expects(a1).returning(r).once()
+        variableInfoProfile.trySetValueFromInfo(a1).get should be (r)
+      }
+    }
+
     describe("#toPrettyString") {
       it("should display the variable name and pretty-stringed value") {
         val expected = "someName = someValue"

--- a/scala-debugger-api/src/test/scala/test/InfoTestClasses.scala
+++ b/scala-debugger-api/src/test/scala/test/InfoTestClasses.scala
@@ -17,6 +17,18 @@ object InfoTestClasses {
   val DefaultException = new NotOverriddenException
   private def throwException() = throw DefaultException
 
+  trait TestCreateInfoProfileTrait extends CreateInfoProfile {
+    override def createRemotely(value: AnyVal): ValueInfoProfile = throwException()
+    override def createRemotely(value: String): ValueInfoProfile = throwException()
+  }
+
+  trait TestMiscInfoProfileTrait extends MiscInfoProfile {
+    override def availableLinesForFile(fileName: String): Option[Seq[Int]] = throwException()
+    override def commandLineArguments: Seq[String] = throwException()
+    override def sourceNameToPaths(sourceName: String): Seq[String] = throwException()
+    override def mainClassName: String = throwException()
+  }
+
   class TestThreadInfoProfile extends TestObjectInfoProfile with ThreadInfoProfile {
     override def typeInfo: ReferenceTypeInfoProfile = throwException()
     override def scalaVirtualMachine: ScalaVirtualMachine = throwException()
@@ -55,14 +67,13 @@ object InfoTestClasses {
     override def toJdiInstance: Value = throwException()
   }
 
-  class TestVariableInfoProfile extends VariableInfoProfile {
+  class TestVariableInfoProfile extends VariableInfoProfile with TestCreateInfoProfileTrait {
     override def typeName: String = throwException()
     override def typeInfo: TypeInfoProfile = throwException()
     override def scalaVirtualMachine: ScalaVirtualMachine = throwException()
     override def name: String = throwException()
     override def toValue: ValueInfoProfile = throwException()
-    override def setValue(value: AnyVal): AnyVal = throwException()
-    override def setValue(value: String): String = throwException()
+    override def setValueFromInfo(valueInfo: ValueInfoProfile): ValueInfoProfile = throwException()
     override def isArgument: Boolean = throwException()
     override def isLocal: Boolean = throwException()
     override def isField: Boolean = throwException()
@@ -115,16 +126,16 @@ object InfoTestClasses {
     override def toJdiInstance: StackFrame = throwException()
   }
 
-  class TestArrayInfoProfile extends TestObjectInfoProfile with ArrayInfoProfile {
+  class TestArrayInfoProfile extends TestObjectInfoProfile with ArrayInfoProfile with TestCreateInfoProfileTrait {
     override def typeInfo: ArrayTypeInfoProfile = throwException()
     override def scalaVirtualMachine: ScalaVirtualMachine = throwException()
     override def length: Int = throwException()
     override def value(index: Int): ValueInfoProfile = throwException()
-    override def setValues(index: Int, values: Seq[Any], srcIndex: Int, length: Int): Seq[Any] = throwException()
-    override def setValues(values: Seq[Any]): Seq[Any] = throwException()
     override def values(index: Int, length: Int): Seq[ValueInfoProfile] = throwException()
     override def values: Seq[ValueInfoProfile] = throwException()
-    override def setValue(index: Int, value: Any): Any = throwException()
+    override def setValueFromInfo(index: Int, value: ValueInfoProfile): ValueInfoProfile = throwException()
+    override def setValuesFromInfo(index: Int, values: Seq[ValueInfoProfile], srcIndex: Int, length: Int): Seq[ValueInfoProfile] = throwException()
+    override def setValuesFromInfo(values: Seq[ValueInfoProfile]): Seq[ValueInfoProfile] = throwException()
     override def toJdiInstance: ArrayReference = throwException()
   }
 


### PR DESCRIPTION
Resolves #213.

1. Refactored create methods into CreateInfoProfile
2. Added setValueFromInfo/setValuesFromInfo to support ValueInfoProfile
3. Updated setValue/setValues to use CreateInfoProfile to create remote values and setValueFromInfo/setValuesFromInfo to set remote values