### PR TITLE
Switched low-level class prepare to suspend all threads instead of just event thread

### DIFF
--- a/scala-debugger-api/src/main/scala/org/scaladebugger/api/lowlevel/classes/StandardClassPrepareManager.scala
+++ b/scala-debugger-api/src/main/scala/org/scaladebugger/api/lowlevel/classes/StandardClassPrepareManager.scala
@@ -42,7 +42,7 @@ class StandardClassPrepareManager(
     val request = Try(eventRequestManager.createClassPrepareRequest(
       Seq(
         EnabledProperty(value = true),
-        SuspendPolicyProperty.EventThread
+        SuspendPolicyProperty.AllThreads
       ) ++ extraArguments: _*
     ))
 

--- a/scala-debugger-api/src/test/scala/org/scaladebugger/api/lowlevel/classes/StandardClassPrepareManagerSpec.scala
+++ b/scala-debugger-api/src/test/scala/org/scaladebugger/api/lowlevel/classes/StandardClassPrepareManagerSpec.scala
@@ -59,7 +59,7 @@ class StandardClassPrepareManagerSpec extends FunSpec with Matchers with MockFac
         // Should set enabled to true by default, and
         // set the suspend policy to vm level by default
         (mockClassPrepareRequest.setSuspendPolicy _)
-          .expects(EventRequest.SUSPEND_EVENT_THREAD).once()
+          .expects(EventRequest.SUSPEND_ALL).once()
         (mockClassPrepareRequest.setEnabled _).expects(true).once()
 
         val actual = classPrepareManager.createClassPrepareRequestWithId(expected.get)
@@ -76,7 +76,7 @@ class StandardClassPrepareManagerSpec extends FunSpec with Matchers with MockFac
         // Should set enabled to true by default, and
         // set the suspend policy to vm level by default
         (mockClassPrepareRequest.setSuspendPolicy _)
-          .expects(EventRequest.SUSPEND_EVENT_THREAD).once()
+          .expects(EventRequest.SUSPEND_ALL).once()
         (mockClassPrepareRequest.setEnabled _).expects(true).once()
 
         val actual = classPrepareManager.createClassPrepareRequestWithId(


### PR DESCRIPTION
Potential race condition can occur if attempting to set pending requests like breakpoints if not all threads are suspended (I think). Seems more reasonable for this request to suspend all threads since it is less frequent after the vm has loaded its initial classes.