### PR TITLE
Fix cache dsl

### DIFF
--- a/scala-debugger-api/src/main/scala/org/scaladebugger/api/dsl/info/ValueInfoDSLWrapper.scala
+++ b/scala-debugger-api/src/main/scala/org/scaladebugger/api/dsl/info/ValueInfoDSLWrapper.scala
@@ -22,7 +22,7 @@ class ValueInfoDSLWrapper[T <: ValueInfoProfile] private[dsl] (
   ): T = {
     import org.scaladebugger.api.dsl.Implicits.ObjectInfoDSL
     valueInfo match {
-      case obj: ObjectInfoProfile => obj.cache()
+      case obj if obj.isObject => obj.toObjectInfo.cache()
       case _                      =>
     }
     valueInfo
@@ -39,7 +39,7 @@ class ValueInfoDSLWrapper[T <: ValueInfoProfile] private[dsl] (
   ): T = {
     import org.scaladebugger.api.dsl.Implicits.ObjectInfoDSL
     valueInfo match {
-      case obj: ObjectInfoProfile => obj.uncache()
+      case obj if obj.isObject => obj.toObjectInfo.uncache()
       case _                      =>
     }
     valueInfo

--- a/scala-debugger-api/src/test/scala/org/scaladebugger/api/dsl/info/ValueInfoDSLWrapperSpec.scala
+++ b/scala-debugger-api/src/test/scala/org/scaladebugger/api/dsl/info/ValueInfoDSLWrapperSpec.scala
@@ -47,6 +47,10 @@ class ValueInfoDSLWrapperSpec extends FunSpec with Matchers
         (mockObjectInfoProfile.uniqueId _).expects()
           .returning(TestUniqueId).once()
 
+        (mockObjectInfoProfile.isObject _).expects().returning(true).once()
+        (mockObjectInfoProfile.toObjectInfo _).expects()
+          .returning(mockObjectInfoProfile).once()
+
         implicit val objectCache: ObjectCache = testObjectCache
         mockObjectInfoProfile.cache()
 
@@ -58,6 +62,10 @@ class ValueInfoDSLWrapperSpec extends FunSpec with Matchers
 
         (mockObjectInfoProfile.scalaVirtualMachine _).expects()
           .returning(testScalaVirtualMachine).once()
+
+        (mockObjectInfoProfile.isObject _).expects().returning(true).once()
+        (mockObjectInfoProfile.toObjectInfo _).expects()
+          .returning(mockObjectInfoProfile).once()
 
         (mockObjectInfoProfile.uniqueId _).expects()
           .returning(TestUniqueId).once()
@@ -73,6 +81,8 @@ class ValueInfoDSLWrapperSpec extends FunSpec with Matchers
         (mockValueInfoProfile.scalaVirtualMachine _).expects()
           .returning(testScalaVirtualMachine).once()
 
+        (mockValueInfoProfile.isObject _).expects().returning(false).once()
+
         mockValueInfoProfile.cache()
 
         testObjectCache.has(TestUniqueId) should be (false)
@@ -85,6 +95,10 @@ class ValueInfoDSLWrapperSpec extends FunSpec with Matchers
 
         (mockObjectInfoProfile.uniqueId _).expects()
           .returning(TestUniqueId).twice()
+
+        (mockObjectInfoProfile.isObject _).expects().returning(true).once()
+        (mockObjectInfoProfile.toObjectInfo _).expects()
+          .returning(mockObjectInfoProfile).once()
 
         implicit val objectCache: ObjectCache = testObjectCache
         objectCache.save(mockObjectInfoProfile)
@@ -100,6 +114,10 @@ class ValueInfoDSLWrapperSpec extends FunSpec with Matchers
         (mockObjectInfoProfile.scalaVirtualMachine _).expects()
           .returning(testScalaVirtualMachine).once()
 
+        (mockObjectInfoProfile.isObject _).expects().returning(true).once()
+        (mockObjectInfoProfile.toObjectInfo _).expects()
+          .returning(mockObjectInfoProfile).once()
+
         (mockObjectInfoProfile.uniqueId _).expects()
           .returning(TestUniqueId).twice()
 
@@ -114,6 +132,8 @@ class ValueInfoDSLWrapperSpec extends FunSpec with Matchers
 
         (mockValueInfoProfile.scalaVirtualMachine _).expects()
           .returning(testScalaVirtualMachine).once()
+
+        (mockValueInfoProfile.isObject _).expects().returning(false).once()
 
         mockValueInfoProfile.uncache()
 

--- a/scala-debugger-api/src/test/scala/org/scaladebugger/api/dsl/info/VariableInfoDSLWrapperSpec.scala
+++ b/scala-debugger-api/src/test/scala/org/scaladebugger/api/dsl/info/VariableInfoDSLWrapperSpec.scala
@@ -50,6 +50,10 @@ class VariableInfoDSLWrapperSpec extends FunSpec with Matchers
         (mockVariableInfoProfile.toValueInfo _).expects()
           .returning(mockObjectInfoProfile).once()
 
+        (mockObjectInfoProfile.isObject _).expects().returning(true).once()
+        (mockObjectInfoProfile.toObjectInfo _).expects()
+          .returning(mockObjectInfoProfile).once()
+
         implicit val objectCache: ObjectCache = testObjectCache
         mockVariableInfoProfile.cache()
 
@@ -68,6 +72,10 @@ class VariableInfoDSLWrapperSpec extends FunSpec with Matchers
         (mockVariableInfoProfile.toValueInfo _).expects()
           .returning(mockObjectInfoProfile).once()
 
+        (mockObjectInfoProfile.isObject _).expects().returning(true).once()
+        (mockObjectInfoProfile.toObjectInfo _).expects()
+          .returning(mockObjectInfoProfile).once()
+
         mockVariableInfoProfile.cache()
 
         testObjectCache.has(TestUniqueId) should be (true)
@@ -82,6 +90,10 @@ class VariableInfoDSLWrapperSpec extends FunSpec with Matchers
           .returning(TestUniqueId).twice()
 
         (mockVariableInfoProfile.toValueInfo _).expects()
+          .returning(mockObjectInfoProfile).once()
+
+        (mockObjectInfoProfile.isObject _).expects().returning(true).once()
+        (mockObjectInfoProfile.toObjectInfo _).expects()
           .returning(mockObjectInfoProfile).once()
 
         implicit val objectCache: ObjectCache = testObjectCache
@@ -102,6 +114,10 @@ class VariableInfoDSLWrapperSpec extends FunSpec with Matchers
           .returning(TestUniqueId).twice()
 
         (mockVariableInfoProfile.toValueInfo _).expects()
+          .returning(mockObjectInfoProfile).once()
+
+        (mockObjectInfoProfile.isObject _).expects().returning(true).once()
+        (mockObjectInfoProfile.toObjectInfo _).expects()
           .returning(mockObjectInfoProfile).once()
 
         testObjectCache.save(mockObjectInfoProfile)


### PR DESCRIPTION
Instead of pattern matching, we need to use the conversion methods.