### PR TITLE
Cleaned Debugger Integration Tests

### DIFF
--- a/scala-debugger-api/src/it/scala/org/scaladebugger/api/debuggers/LaunchingDebuggerIntegrationSpec.scala
+++ b/scala-debugger-api/src/it/scala/org/scaladebugger/api/debuggers/LaunchingDebuggerIntegrationSpec.scala
@@ -5,12 +5,12 @@ import java.util.concurrent.atomic.AtomicBoolean
 
 import org.scalatest.concurrent.Eventually
 import org.scalatest.time.{Milliseconds, Seconds, Span}
-import org.scalatest.{ParallelTestExecution, FunSpec, Matchers}
+import org.scalatest.{ParallelTestExecution, BeforeAndAfter, FunSpec, Matchers}
 import org.scaladebugger.api.utils.{JDITools, Logging}
 import test.TestUtilities
 
 class LaunchingDebuggerIntegrationSpec  extends FunSpec with Matchers
-  with Eventually with TestUtilities with Logging
+  with BeforeAndAfter with Eventually with TestUtilities with Logging
   with ParallelTestExecution
 {
   implicit override val patienceConfig = PatienceConfig(
@@ -18,19 +18,37 @@ class LaunchingDebuggerIntegrationSpec  extends FunSpec with Matchers
     interval = scaled(Span(5, Milliseconds))
   )
 
-  describe("LaunchingDebugger") {
-    it("should be able to start a JVM and connect to it") {
-      val launchedJvmConnected = new AtomicBoolean(false)
+  @volatile private var launchingDebugger : Option[LaunchingDebugger] = None
 
-      val className = "org.scaladebugger.test.misc.LaunchingMain"
-      val classpath = JDITools.jvmClassPath
-      val jvmOptions = Seq("-classpath", classpath)
-      val launchingDebugger = LaunchingDebugger(
+  // Before each test, initialize a debugger
+  before {
+    val className = "org.scaladebugger.test.misc.LaunchingMain"
+    val classpath = JDITools.jvmClassPath
+    val jvmOptions = Seq("-classpath", classpath)
+    launchingDebugger = Some(
+      LaunchingDebugger(
         className = className,
         jvmOptions = jvmOptions,
         suspend = false
       )
-      launchingDebugger.start { _ => launchedJvmConnected.set(true) }
+    )
+  }
+
+  // After each test, stop and destroy the debugger
+  after {
+    launchingDebugger.foreach(_.stop())
+    launchingDebugger = None
+  }
+
+  describe("LaunchingDebugger") {
+    it("should be able to start a JVM and connect to it") {
+      val launchedJvmConnected = new AtomicBoolean(false)
+
+      launchingDebugger.foreach(
+        _.start { _ =>
+          launchedJvmConnected.set(true)
+        }
+      )
 
       // Keep checking back until the launched JVM has been connected
       eventually {


### PR DESCRIPTION
Modify debugger integration tests to prevent them from spawning "leftover" processes (processes that continue running after the test suite is finished running). For #13.
- Initialize all debuggers in the before blocks for each test
- Explicitly stop() each debugger and destroy them in the after blocks
- Wrap debugger objects in Options to achieve the above
