### PR TITLE
Add persistent pipeline support

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -67,8 +67,8 @@ lazy val scalaDebuggerTool = project
 lazy val sbtScalaDebuggerPlugin = project
   .in(file("sbt-scala-debugger-plugin"))
   .settings(Common.settings: _*)
+  .settings(SbtPlugin.settings: _*)
   .settings(name := "sbt-scala-debugger")
-  .settings(sbtPlugin := true)
 
 //
 // MAIN PROJECT CONFIGURATION

--- a/project/SbtPlugin.scala
+++ b/project/SbtPlugin.scala
@@ -1,0 +1,10 @@
+import sbt.Keys._
+
+object SbtPlugin {
+  /** Sbt plugin-specific project settings. */
+  val settings = Seq(
+    sbtPlugin := true,
+    scalaVersion := "2.10.6",
+    crossScalaVersions := Seq("2.10.6")
+  )
+}


### PR DESCRIPTION
Adds `toIterable` to pipeline data structure, enabling persistent pipeline data. 