### PR TITLE
Attempt to fix inconsistencies in Scala210Object/ReferenceTypeInfo

### DIFF
--- a/scala-debugger-api/src/it/scala/org/scaladebugger/api/profiles/scala210/info/Scala210ObjectInfoIntegrationSpec.scala
+++ b/scala-debugger-api/src/it/scala/org/scaladebugger/api/profiles/scala210/info/Scala210ObjectInfoIntegrationSpec.scala
@@ -76,9 +76,9 @@ class Scala210ObjectInfoIntegrationSpec extends ParallelMockFunSpec
             .flatMap(_.visibleFields)
             .map(_.toJdiInstance.name)
 
-          fieldNames.length should ===(4)
-          indexedFieldNames.length should ===(4)
-          typeRefVisibleFieldNames.length should ===(4)
+          fieldNames should have length 4
+          indexedFieldNames should have length 4
+          typeRefVisibleFieldNames should have length 4
 
           fieldNames should (
             contain theSameElementsAs indexedFieldNames and

--- a/scala-debugger-api/src/it/scala/org/scaladebugger/api/profiles/scala210/info/Scala210ObjectInfoIntegrationSpec.scala
+++ b/scala-debugger-api/src/it/scala/org/scaladebugger/api/profiles/scala210/info/Scala210ObjectInfoIntegrationSpec.scala
@@ -41,5 +41,52 @@ class Scala210ObjectInfoIntegrationSpec extends ParallelMockFunSpec
         })
       }
     }
+
+    it("should be consistent in .fields() and .indexedFields() calls and with Scala210ReferenceType") {
+      val testClass = "org.scaladebugger.test.info.Fields"
+      val testFile = JDITools.scalaClassStringToFileString(testClass)
+
+      @volatile var t: Option[ThreadInfo] = None
+      val s = DummyScalaVirtualMachine.newInstance()
+
+      // NOTE: Do not resume so we can check the variables at the stack frame
+      s.withProfile(Scala210DebugProfile.Name)
+        .getOrCreateBreakpointRequest(testFile, 63, NoResume)
+        .foreach(e => t = Some(e.thread))
+
+      withVirtualMachine(testClass, pendingScalaVirtualMachines = Seq(s)) { (s) =>
+        logTimeTaken(eventually {
+          val inheritedClassVar = t
+            .flatMap(_.findVariableByName("inheritedClass"))
+          val inheritedClassObject = inheritedClassVar
+            .map(_.toValueInfo.toObjectInfo)
+          val inheritedClassTypeRef = inheritedClassVar
+            .map(_.toValueInfo.`type`.toReferenceType)
+
+          val fieldNames = inheritedClassObject
+            .toList
+            .flatMap(_.fields)
+            .map(_.toJdiInstance.name)
+          val indexedFieldNames = inheritedClassObject
+            .toList
+            .flatMap(_.indexedFields)
+            .map(_.toJdiInstance.name)
+          val typeRefVisibleFieldNames = inheritedClassTypeRef
+            .toList
+            .flatMap(_.visibleFields)
+            .map(_.toJdiInstance.name)
+
+          fieldNames.length should ===(4)
+          indexedFieldNames.length should ===(4)
+          typeRefVisibleFieldNames.length should ===(4)
+
+          fieldNames should (
+            contain theSameElementsAs indexedFieldNames and
+            contain theSameElementsAs typeRefVisibleFieldNames
+          )
+
+        })
+      }
+    }
   }
 }

--- a/scala-debugger-api/src/main/scala/org/scaladebugger/api/profiles/scala210/info/Scala210FieldTransformationRules.scala
+++ b/scala-debugger-api/src/main/scala/org/scaladebugger/api/profiles/scala210/info/Scala210FieldTransformationRules.scala
@@ -18,7 +18,7 @@ trait Scala210FieldTransformationRules {
   private val ignoreOrigin = Seq("scala.")
 
   // TODO: Handle infinitely-recursive fields when expanding
-  def transformField(field: FieldVariableInfo, isInStaticContext: Boolean = false): Seq[FieldVariableInfo] = {
+  protected def transformField(field: FieldVariableInfo, isInStaticContext: Boolean = false): Seq[FieldVariableInfo] = {
     val jField = field.toJavaInfo
     val value = if (field.toJdiInstance.isStatic == isInStaticContext) Some(field.toValueInfo)
                 else None

--- a/scala-debugger-api/src/main/scala/org/scaladebugger/api/profiles/scala210/info/Scala210FieldTransformationRules.scala
+++ b/scala-debugger-api/src/main/scala/org/scaladebugger/api/profiles/scala210/info/Scala210FieldTransformationRules.scala
@@ -1,0 +1,41 @@
+package org.scaladebugger.api.profiles.scala210.info
+
+import org.scaladebugger.api.profiles.traits.info.FieldVariableInfo
+
+trait Scala210FieldTransformationRules {
+  // Will retrieve fields of these objects
+  private val expandNames = Seq("$outer")
+
+  // Will skip these fields
+  // TODO: Provide better means of skipping executionStart
+  //       since this avoids it even if someone added it directly
+  private val ignoreNames = Seq("MODULE$", "executionStart", "serialVersionUID")
+
+  // Will skip fields whose names start with these prefixes
+  private val ignoreNamePrefix = Seq("scala$")
+
+  // Will skip fields whose origin starts with these strings
+  private val ignoreOrigin = Seq("scala.")
+
+  // TODO: Handle infinitely-recursive fields when expanding
+  def transformField(field: FieldVariableInfo): Seq[FieldVariableInfo] = {
+    val jField = field.toJavaInfo
+    val value = field.toValueInfo
+
+    // If the field is something we should ignore directly, do so
+    if (ignoreNames.contains(jField.name)) Nil
+
+    // If the field name starts with a prefix we should ignore, do so
+    else if (ignoreNamePrefix.exists(jField.name.startsWith)) Nil
+
+    // If the field's origin starts with an origin we don't want, ignore it
+    else if (ignoreOrigin.exists(jField.declaringTypeInfo.name.startsWith)) Nil
+
+    // If the field is one that should be expanded, do so
+    else if (value.isObject && expandNames.contains(jField.name))
+      value.toObjectInfo.fields.flatMap(transformField)
+
+    // Otherwise, return the normal field
+    else Seq(field)
+  }
+}

--- a/scala-debugger-api/src/main/scala/org/scaladebugger/api/profiles/scala210/info/Scala210ObjectInfo.scala
+++ b/scala-debugger-api/src/main/scala/org/scaladebugger/api/profiles/scala210/info/Scala210ObjectInfo.scala
@@ -1,6 +1,6 @@
 package org.scaladebugger.api.profiles.scala210.info
 
-import com.sun.jdi.{ObjectReference, ReferenceType, ThreadReference, VirtualMachine}
+import com.sun.jdi.{ObjectReference, ReferenceType, VirtualMachine}
 import org.scaladebugger.api.profiles.pure.info.PureObjectInfo
 import org.scaladebugger.api.profiles.traits.info.{FieldVariableInfo, InfoProducer}
 import org.scaladebugger.api.virtualmachines.ScalaVirtualMachine
@@ -29,7 +29,7 @@ class Scala210ObjectInfo(
 )(
   _virtualMachine = _virtualMachine,
   _referenceType = _referenceType
-) {
+) with Scala210FieldTransformationRules {
   /**
    * Returns whether or not this info profile represents the low-level Java
    * implementation.
@@ -40,54 +40,13 @@ class Scala210ObjectInfo(
    */
   override def isJavaInfo: Boolean = false
 
-
   /**
    * Returns all visible fields contained in this object.
    *
    * @note Provides no offset index information!
    * @return The profiles wrapping the visible fields in this object
    */
-  override def fields: Seq[FieldVariableInfo] = {
-    val baseFields = super.fields
-
-    // Will retrieve fields of these objects
-    val expandNames = Seq("$outer")
-
-    // Will skip these fields
-    // TODO: Provide better means of skipping executionStart
-    //       since this avoids it even if someone added it directly
-    val ignoreNames = Seq("MODULE$", "executionStart", "serialVersionUID")
-
-    // Will skip fields whose names start with these prefixes
-    val ignoreNamePrefix = Seq("scala$")
-
-    // Will skip fields whose origin starts with these strings
-    val ignoreOrigin = Seq("scala.")
-
-    // TODO: Handle infinitely-recursive fields when expanding
-    def transformField(field: FieldVariableInfo): Seq[FieldVariableInfo] = {
-      val jField = field.toJavaInfo
-      val value = field.toValueInfo
-
-      // If the field is something we should ignore directly, do so
-      if (ignoreNames.contains(jField.name)) Nil
-
-      // If the field name starts with a prefix we should ignore, do so
-      else if (ignoreNamePrefix.exists(jField.name.startsWith)) Nil
-
-      // If the field's origin starts with an origin we don't want, ignore it
-      else if (ignoreOrigin.exists(jField.declaringType.name.startsWith)) Nil
-
-      // If the field is one that should be expanded, do so
-      else if (value.isObject && expandNames.contains(jField.name))
-        value.toObjectInfo.fields.flatMap(transformField)
-
-      // Otherwise, return the normal field
-      else Seq(field)
-    }
-
-    baseFields.flatMap(transformField)
-  }
+  override def fields: Seq[FieldVariableInfo] = super.fields.flatMap(transformField)
 
   /**
    * Returns the object's field with the specified name.
@@ -98,4 +57,24 @@ class Scala210ObjectInfo(
   override def fieldOption(
     name: String
   ): Option[FieldVariableInfo] = fields.find(_.name == name)
+
+  /**
+    * Returns all visible fields contained in this object with offset index.
+    *
+    * @return The profiles wrapping the visible fields in this object
+    */
+  override def indexedFields: Seq[FieldVariableInfo] = fields.zipWithIndex.map {
+    case (f, i) => newFieldProfile(f.toJdiInstance, i)
+  }
+
+  /**
+    * Returns the object's field with the specified name with offset index
+    * information.
+    *
+    * @param name The name of the field
+    * @return Some profile wrapping the field, or None if doesn't exist
+    */
+  override def indexedFieldOption(
+    name: String
+  ): Option[FieldVariableInfo] = indexedFields.find(_.name == name)
 }

--- a/scala-debugger-api/src/main/scala/org/scaladebugger/api/profiles/scala210/info/Scala210ObjectInfo.scala
+++ b/scala-debugger-api/src/main/scala/org/scaladebugger/api/profiles/scala210/info/Scala210ObjectInfo.scala
@@ -46,7 +46,7 @@ class Scala210ObjectInfo(
    * @note Provides no offset index information!
    * @return The profiles wrapping the visible fields in this object
    */
-  override def fields: Seq[FieldVariableInfo] = toJavaInfo.fields.flatMap(transformField(_))
+  override def fields: Seq[FieldVariableInfo] = super.fields.flatMap(transformField(_))
 
   /**
    * Returns the object's field with the specified name.

--- a/scala-debugger-api/src/main/scala/org/scaladebugger/api/profiles/scala210/info/Scala210ObjectInfo.scala
+++ b/scala-debugger-api/src/main/scala/org/scaladebugger/api/profiles/scala210/info/Scala210ObjectInfo.scala
@@ -46,7 +46,7 @@ class Scala210ObjectInfo(
    * @note Provides no offset index information!
    * @return The profiles wrapping the visible fields in this object
    */
-  override def fields: Seq[FieldVariableInfo] = super.fields.flatMap(transformField)
+  override def fields: Seq[FieldVariableInfo] = super.fields.flatMap(transformField(_))
 
   /**
    * Returns the object's field with the specified name.

--- a/scala-debugger-api/src/main/scala/org/scaladebugger/api/profiles/scala210/info/Scala210ObjectInfo.scala
+++ b/scala-debugger-api/src/main/scala/org/scaladebugger/api/profiles/scala210/info/Scala210ObjectInfo.scala
@@ -46,7 +46,7 @@ class Scala210ObjectInfo(
    * @note Provides no offset index information!
    * @return The profiles wrapping the visible fields in this object
    */
-  override def fields: Seq[FieldVariableInfo] = super.fields.flatMap(transformField(_))
+  override def fields: Seq[FieldVariableInfo] = toJavaInfo.fields.flatMap(transformField(_))
 
   /**
    * Returns the object's field with the specified name.

--- a/scala-debugger-api/src/main/scala/org/scaladebugger/api/profiles/scala210/info/Scala210ReferenceTypeInfo.scala
+++ b/scala-debugger-api/src/main/scala/org/scaladebugger/api/profiles/scala210/info/Scala210ReferenceTypeInfo.scala
@@ -40,7 +40,7 @@ class Scala210ReferenceTypeInfo(
     * @return The collection of fields as variable info profiles
     */
   override def allFields: Seq[FieldVariableInfo] =
-    super.allFields.flatMap(transformField(_, isInStaticContext = true))
+    toJavaInfo.allFields.flatMap(transformField(_, isInStaticContext = true))
 
    /**
     * Retrieves unhidden and unambiguous fields in this type. Fields hidden
@@ -52,7 +52,7 @@ class Scala210ReferenceTypeInfo(
     * @return The collection of fields as variable info profiles
     */
   override def visibleFields: Seq[FieldVariableInfo] =
-    super.visibleFields.flatMap(transformField(_, isInStaticContext = true))
+    toJavaInfo.visibleFields.flatMap(transformField(_, isInStaticContext = true))
 
   /**
    * Retrieves the visible field with the matching name.

--- a/scala-debugger-api/src/main/scala/org/scaladebugger/api/profiles/scala210/info/Scala210ReferenceTypeInfo.scala
+++ b/scala-debugger-api/src/main/scala/org/scaladebugger/api/profiles/scala210/info/Scala210ReferenceTypeInfo.scala
@@ -39,7 +39,8 @@ class Scala210ReferenceTypeInfo(
     * @note Provides no offset index information!
     * @return The collection of fields as variable info profiles
     */
-  override def allFields: Seq[FieldVariableInfo] = super.allFields.flatMap(transformField)
+  override def allFields: Seq[FieldVariableInfo] =
+    super.allFields.flatMap(transformField(_, isInStaticContext = true))
 
    /**
     * Retrieves unhidden and unambiguous fields in this type. Fields hidden
@@ -50,7 +51,8 @@ class Scala210ReferenceTypeInfo(
     * @note Provides offset index information!
     * @return The collection of fields as variable info profiles
     */
-  override def visibleFields: Seq[FieldVariableInfo] = super.visibleFields.flatMap(transformField)
+  override def visibleFields: Seq[FieldVariableInfo] =
+    super.visibleFields.flatMap(transformField(_, isInStaticContext = true))
 
   /**
    * Retrieves the visible field with the matching name.

--- a/scala-debugger-api/src/main/scala/org/scaladebugger/api/profiles/scala210/info/Scala210ReferenceTypeInfo.scala
+++ b/scala-debugger-api/src/main/scala/org/scaladebugger/api/profiles/scala210/info/Scala210ReferenceTypeInfo.scala
@@ -40,7 +40,7 @@ class Scala210ReferenceTypeInfo(
     * @return The collection of fields as variable info profiles
     */
   override def allFields: Seq[FieldVariableInfo] =
-    toJavaInfo.allFields.flatMap(transformField(_, isInStaticContext = true))
+    super.allFields.flatMap(transformField(_, isInStaticContext = true))
 
    /**
     * Retrieves unhidden and unambiguous fields in this type. Fields hidden
@@ -52,7 +52,7 @@ class Scala210ReferenceTypeInfo(
     * @return The collection of fields as variable info profiles
     */
   override def visibleFields: Seq[FieldVariableInfo] =
-    toJavaInfo.visibleFields.flatMap(transformField(_, isInStaticContext = true))
+    super.visibleFields.flatMap(transformField(_, isInStaticContext = true))
 
   /**
    * Retrieves the visible field with the matching name.

--- a/scala-debugger-api/src/main/scala/org/scaladebugger/api/profiles/scala210/info/Scala210ReferenceTypeInfo.scala
+++ b/scala-debugger-api/src/main/scala/org/scaladebugger/api/profiles/scala210/info/Scala210ReferenceTypeInfo.scala
@@ -21,7 +21,7 @@ class Scala210ReferenceTypeInfo(
   scalaVirtualMachine = scalaVirtualMachine,
   infoProducer = infoProducer,
   _referenceType = _referenceType
-) {
+) with Scala210FieldTransformationRules {
   /**
    * Returns whether or not this info profile represents the low-level Java
    * implementation.
@@ -33,11 +33,53 @@ class Scala210ReferenceTypeInfo(
   override def isJavaInfo: Boolean = false
 
   /**
+    * Retrieves all fields declared in this type, its superclasses, implemented
+    * interfaces, and superinterfaces.
+    *
+    * @note Provides no offset index information!
+    * @return The collection of fields as variable info profiles
+    */
+  override def allFields: Seq[FieldVariableInfo] = super.allFields.flatMap(transformField)
+
+   /**
+    * Retrieves unhidden and unambiguous fields in this type. Fields hidden
+    * by other fields with the same name (in a more recently inherited class)
+    * are not included. Fields that are ambiguously multiply inherited are also
+    * not included. All other inherited fields are included.
+    *
+    * @note Provides offset index information!
+    * @return The collection of fields as variable info profiles
+    */
+  override def visibleFields: Seq[FieldVariableInfo] = super.visibleFields.flatMap(transformField)
+
+  /**
    * Retrieves the visible field with the matching name.
    *
    * @param name The name of the field to retrieve
    * @return Some field as a variable info profile, or None if doesn't exist
    */
   override def fieldOption(name: String): Option[FieldVariableInfo] =
-    allFields.find(_.name == name)
+    visibleFields.find(_.name == name)
+
+  /**
+    * Retrieves unhidden and unambiguous fields in this type. Fields hidden
+    * by other fields with the same name (in a more recently inherited class)
+    * are not included. Fields that are ambiguously multiply inherited are also
+    * not included. All other inherited fields are included. Offset index
+    * information is included.
+    *
+    * @return The collection of fields as variable info profiles
+    */
+  override def indexedVisibleFields: Seq[FieldVariableInfo] = visibleFields.zipWithIndex.map {
+    case (f, i) => newFieldProfile(f.toJdiInstance, i)
+  }
+
+  /** Retrieves the visible field with the matching name with offset index
+   * information.
+   *
+   * @param name The name of the field to retrieve
+   * @return Some field as a variable info profile, or None if doesn't exist
+   */
+  override def indexedFieldOption(name: String): Option[FieldVariableInfo] =
+    indexedVisibleFields.find(_.name == name)
 }

--- a/scala-debugger-api/src/main/scala/org/scaladebugger/api/profiles/traits/info/FieldVariableInfo.scala
+++ b/scala-debugger-api/src/main/scala/org/scaladebugger/api/profiles/traits/info/FieldVariableInfo.scala
@@ -1,5 +1,7 @@
 package org.scaladebugger.api.profiles.traits.info
 
+import com.sun.jdi.Field
+
 import scala.util.Try
 
 
@@ -18,6 +20,13 @@ trait FieldVariableInfo
    *         to Java
    */
   override def toJavaInfo: FieldVariableInfo
+
+  /**
+    * Returns the JDI representation this profile instance wraps.
+    *
+    * @return The JDI instance
+    */
+  override def toJdiInstance: Field
 
   /**
    * Returns the parent that contains this field.


### PR DESCRIPTION
This addresses the fact that `.fields()` and `.indexedFields()` were inconsistent in `Scala210ObjectInfo`. Also, while fixing that, I also noticed that `Scala210ReferenceTypeInfo` is probably inconsistent with `Scala210ObjectInfo` too, since it doesn't use the same field transformation rules.