### PR TITLE
Update cookbook examples for 1.1.0-M3

### DIFF
--- a/docs/src/api/cookbook/creating-a-breakpoint.md
+++ b/docs/src/api/cookbook/creating-a-breakpoint.md
@@ -24,7 +24,7 @@ import org.scaladebugger.api.utils.JDITools
 object SingleBreakpointExample extends App {
   // Get the executing class name (remove $ from object class name)
   val klass = SingleBreakpointMainClass.getClass
-  val className = klass.name.replaceAllLiterally("$", "")
+  val className = klass.getName.replaceAllLiterally("$", "")
 
   // Add our main class to the classpath used to launch the class
   val classpath = JDITools.jvmClassPath
@@ -45,9 +45,9 @@ object SingleBreakpointExample extends App {
 
     // On reaching a breakpoint for our class below, print out our result
     // and shut down our debugger
-    s.onUnsafeBreakpoint(fileName, lineNumber).foreach(e => {
-      val path = e.location().sourcePath()
-      val line = e.location().lineNumber()
+    s.getOrCreateBreakpointRequest(fileName, lineNumber).foreach(e => {
+      val path = e.location.sourcePath
+      val line = e.location.lineNumber
 
       println(s"Reached breakpoint for $path:$line")
       launchingDebugger.stop()

--- a/docs/src/api/cookbook/creating-a-launching-debugger.md
+++ b/docs/src/api/cookbook/creating-a-launching-debugger.md
@@ -25,7 +25,7 @@ import org.scaladebugger.api.utils.JDITools
 object LaunchingDebuggerExample extends App {
   // Get the executing class name (remove $ from object class name)
   val klass = SomeLaunchingMainClass.getClass
-  val className = klass.name.replaceAllLiterally("$", "")
+  val className = klass.getName.replaceAllLiterally("$", "")
 
   // Add our main class to the classpath used to launch the class
   val classpath = JDITools.jvmClassPath

--- a/docs/src/api/cookbook/creating-a-listening-debugger.md
+++ b/docs/src/api/cookbook/creating-a-listening-debugger.md
@@ -28,7 +28,7 @@ import org.scaladebugger.api.utils.JDITools
 object ListeningDebuggerExample extends App {
   // Get the executing class name (remove $ from object class name)
   val klass = SomeListeningMainClass.getClass
-  val className = klass.name.replaceAllLiterally("$", "")
+  val className = klass.getName.replaceAllLiterally("$", "")
 
   val listeningDebugger = ListeningDebugger(port = 5005)
 

--- a/docs/src/api/cookbook/creating-an-attaching-debugger.md
+++ b/docs/src/api/cookbook/creating-an-attaching-debugger.md
@@ -29,7 +29,7 @@ import org.scaladebugger.api.utils.JDITools
 object AttachingDebuggerExample extends App {
   // Get the executing class name (remove $ from object class name)
   val klass = SomeAttachingMainClass.getClass
-  val className = klass.name.replaceAllLiterally("$", "")
+  val className = klass.getName.replaceAllLiterally("$", "")
 
   // Spawn the target JVM process using our helper function
   val targetJvmProcess = JDITools.spawn(

--- a/docs/src/api/cookbook/stepping-over-a-line-of-code.md
+++ b/docs/src/api/cookbook/stepping-over-a-line-of-code.md
@@ -24,7 +24,7 @@ import org.scaladebugger.api.utils.JDITools
 object SingleStepExample extends App {
   // Get the executing class name (remove $ from object class name)
   val klass = SingleStepMainClass.getClass
-  val className = klass.name.replaceAllLiterally("$", "")
+  val className = klass.getName.replaceAllLiterally("$", "")
 
   // Add our main class to the classpath used to launch the class
   val classpath = JDITools.jvmClassPath
@@ -45,17 +45,17 @@ object SingleStepExample extends App {
 
     // On reaching a breakpoint for our class below, step to the next
     // line and then shutdown our debugger
-    s.onUnsafeBreakpoint(fileName, lineNumber).foreach(be => {
-      val path = be.location().sourcePath()
-      val line = be.location().lineNumber()
+    s.getOrCreateBreakpointRequest(fileName, lineNumber).foreach(be => {
+      val path = be.location.sourcePath
+      val line = be.location.lineNumber
 
       println(s"Reached breakpoint for $path:$line")
 
       // Step methods return a future that occurs when the step finishes
       import scala.concurrent.ExecutionContext.Implicits.global
-      s.stepOverLine(be.thread()).foreach(se => {
-        val path = se.location().sourcePath()
-        val line = se.location().lineNumber()
+      s.stepOverLine(be.thread).foreach(se => {
+        val path = se.location.sourcePath()
+        val line = se.location.lineNumber
 
         println(s"Stepped to $path:$line")
         launchingDebugger.stop()

--- a/scala-debugger-docs/README.md
+++ b/scala-debugger-docs/README.md
@@ -3,7 +3,7 @@
 To generate and serve the docs, run the following:
 
 ```
-sbt scalaDebuggerDocs/run -gs --allow-unsupported-media-types
+sbt 'scalaDebuggerDocs/run -gs --allow-unsupported-media-types'
 ```
 
 Note the use of `--allow-unsupported-media-types`, which is needed to serve


### PR DESCRIPTION
This updates the cookbook examples to the latest code (see PR in scala-debugger-samples for test code for examples.